### PR TITLE
Update Client.php for fix prepareScopes method

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -175,8 +175,8 @@ class Google_Client
   public function prepareScopes()
   {
     if (empty($this->requestedScopes)) {
-      foreach ($this->availableScopes as $service => $serviceScopes) {
-        array_push($this->requestedScopes, $serviceScopes[0]);
+      foreach ($this->availableScopes as $service => &$serviceScopes) {
+          $this->requestedScopes = array_merge($this->requestedScopes, $serviceScopes);
       }
     }
     $scopes = implode(' ', $this->requestedScopes);


### PR DESCRIPTION
prepareScopes method contains a bug as it is only adding the first serviceScopes element to the requestedScopes array with the array_push. The fix consists in perform an array_merge between requestedScopes and given serviceScopes.
