### PR TITLE
Strip nulls from simplified objects

### DIFF
--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -114,7 +114,7 @@ class Google_Model implements ArrayAccess
     foreach($this->data as $key => $val) {
       if ($val instanceof Google_Model) {
         $object->$key = $val->toSimpleObject();
-      } else {
+      } else if ($val != null) {
         $object->$key = $val;
       }
     }

--- a/tests/general/ApiModelTest.php
+++ b/tests/general/ApiModelTest.php
@@ -26,10 +26,13 @@ class ApiModelTest extends BaseTest {
     $model->publicA = "This is a string";
     $model2 = new Google_Model();
     $model2->publicC = 12345;
+    $model2->publicD = null;
     $model->publicB = $model2;
     $string = json_encode($model->toSimpleObject());
     $data = json_decode($string, true);
     $this->assertEquals(12345, $data['publicB']['publicC']);
     $this->assertEquals("This is a string", $data['publicA']);
+    $this->assertArrayNotHasKey("publicD", $data['publicB']);
+    $this->assertArrayNotHasKey("data", $data);
   }
 }


### PR DESCRIPTION
The current code was allowing through null objects in the $data property,
and also had an insufficiently strict condition in the properties, which
would have filtered out false variables. It is possible that this change
may need to be tweaked, but I think it covers the primary cases.
