### PR TITLE
Remove auto-scopes, and make request serialisable

### DIFF
--- a/examples/fileupload.php
+++ b/examples/fileupload.php
@@ -46,6 +46,7 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
+$client->addScope("https://www.googleapis.com/auth/drive");
 $service = new Google_Service_Drive($client);
 
 if (isset($_REQUEST['logout'])) {

--- a/examples/idtoken.php
+++ b/examples/idtoken.php
@@ -33,7 +33,7 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
-$client->setScopes('https://www.googleapis.com/auth/userinfo.email');
+$client->setScopes('email');
 
 /************************************************
   If we're logging out we just need to clear our

--- a/examples/multi-api.php
+++ b/examples/multi-api.php
@@ -42,6 +42,8 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
+$client->addScope("https://www.googleapis.com/auth/drive");
+$client->addScope("https://www.googleapis.com/auth/youtube");
 
 /************************************************
   We are going to create both YouTube and Drive

--- a/examples/simple-query.php
+++ b/examples/simple-query.php
@@ -77,7 +77,7 @@ foreach ($results as $item) {
 $client->setDefer(true);
 $optParams = array('filter' => 'free-ebooks');
 $request = $service->volumes->listVolumes('Henry David Thoreau', $optParams);
-$results = $request->execute();
+$results = $client->execute($request);
 
 echo "<h3>Results Of Deferred Call:</h3>";
 foreach ($results as $item) {

--- a/examples/simplefileupload.php
+++ b/examples/simplefileupload.php
@@ -46,6 +46,7 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
+$client->addScope("https://www.googleapis.com/auth/drive")
 $service = new Google_Service_Drive($client);
 
 if (isset($_REQUEST['logout'])) {

--- a/examples/user-example.php
+++ b/examples/user-example.php
@@ -41,6 +41,7 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
+$client->addScope("https://www.googleapis.com/auth/urlshortener");
 
 /************************************************
   When we create the service here, we pass the

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -99,7 +99,6 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
     // fetch the access token
     $request = $this->client->getIo()->makeRequest(
         new Google_Http_Request(
-            $this->client,
             self::OAUTH2_TOKEN_URI,
             'POST',
             array(),
@@ -302,7 +301,6 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
   private function refreshTokenRequest($params)
   {
     $http = new Google_Http_Request(
-        $this->client,
         self::OAUTH2_TOKEN_URI,
         'POST',
         array(),
@@ -343,7 +341,6 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       $token = $this->token['access_token'];
     }
     $request = new Google_Http_Request(
-        $this->client,
         self::OAUTH2_REVOKE_URI,
         'POST',
         array(),
@@ -409,7 +406,6 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
     // This relies on makeRequest caching certificate responses.
     $request = $this->client->getIo()->makeRequest(
         new Google_Http_Request(
-            $this->client,
             $url
         )
     );

--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -70,7 +70,7 @@ class Google_Http_Batch
     $body .= "\n--{$this->boundary}--";
 
     $url = $this->base_path . '/batch';
-    $httpRequest = new Google_Http_Request($this->client, $url, 'POST');
+    $httpRequest = new Google_Http_Request($url, 'POST');
     $httpRequest->setRequestHeaders(
         array('Content-Type' => 'multipart/mixed; boundary=' . $this->boundary)
     );
@@ -110,7 +110,7 @@ class Google_Http_Batch
           $status = $status[1];
 
           list($partHeaders, $partBody) = $this->client->getIo()->ParseHttpResponse($part, false);
-          $response = new Google_Http_Request($this->client, "");
+          $response = new Google_Http_Request("");
           $response->setResponseHttpCode($status);
           $response->setResponseHeaders($partHeaders);
           $response->setResponseBody($partBody);

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -136,7 +136,6 @@ class Google_Http_MediaFileUpload
     );
 
     $httpRequest = new Google_Http_Request(
-        $this->client,
         $this->resumeUri,
         'PUT',
         $headers,
@@ -217,9 +216,8 @@ class Google_Http_MediaFileUpload
   
   private function transformToUploadUrl()
   {
-    $base = $this->request->getBasePath();
-    $url = str_replace($base, $base . "/upload", $this->request->getBaseUrl());
-    $this->request->setBaseUrl($url);
+    $base = $this->request->getBaseComponent();
+    $this->request->setBaseComponent($base . '/upload');
   }
 
   /**

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -40,6 +40,9 @@ class Google_Http_REST
    */
   public static function execute(Google_Client $client, Google_Http_Request $req)
   {
+    if (!$req->getBaseComponent()) {
+      $req->setBaseComponent($client->getBasePath());
+    }
     $httpRequest = $client->getIo()->makeRequest($req);
     $httpRequest->setExpectedClass($req->getExpectedClass());
     return self::decodeHttpResponse($httpRequest);

--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -95,26 +95,27 @@ class Google_Model implements ArrayAccess
    * due to the usage of reflection, but shouldn't be called
    * a whole lot, and is the most straightforward way to filter.
    */
-  public function toSimpleObject() {
+  public function toSimpleObject()
+  {
     $object = new stdClass();
 
     // Process all public properties.
     $reflect = new ReflectionObject($this);
     $props = $reflect->getProperties(ReflectionProperty::IS_PUBLIC);
-    foreach($props as $member) {
+    foreach ($props as $member) {
       $name = $member->getName();
       if ($this->$name instanceof Google_Model) {
         $object->$name = $this->$name->toSimpleObject();
-      } else if ($this->$name != null) {
+      } else if ($this->$name !== null) {
         $object->$name = $this->$name;
       }
     }
 
     // Process all other data.
-    foreach($this->data as $key => $val) {
+    foreach ($this->data as $key => $val) {
       if ($val instanceof Google_Model) {
         $object->$key = $val->toSimpleObject();
-      } else if ($val != null) {
+      } else if ($val !== null) {
         $object->$key = $val;
       }
     }

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -159,7 +159,6 @@ class Google_Service_Resource
         $parameters
     );
     $httpRequest = new Google_Http_Request(
-        $this->client,
         $url,
         $method['httpMethod'],
         null,
@@ -192,7 +191,7 @@ class Google_Service_Resource
       return $httpRequest;
     }
 
-    return $httpRequest->execute();
+    return $this->client->execute($httpRequest);
   }
 
   protected function convertToArrayAndStripNulls($o)

--- a/tests/general/ApiCacheParserTest.php
+++ b/tests/general/ApiCacheParserTest.php
@@ -25,13 +25,13 @@ require_once 'Google/Http/Request.php';
 class ApiCacheParserTest extends BaseTest {
   public function testIsResponseCacheable() {
     $client = $this->getClient();
-    $resp = new Google_Http_Request($client, 'http://localhost', 'POST');
+    $resp = new Google_Http_Request('http://localhost', 'POST');
     $result = Google_Http_CacheParser::isResponseCacheable($resp);
     $this->assertFalse($result);
 
     // The response has expired, and we don't have an etag for
     // revalidation.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600, must-revalidate',
@@ -43,7 +43,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse($result);
 
     // Verify cacheable responses.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600, must-revalidate',
@@ -56,7 +56,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertTrue($result);
 
     // Verify that responses to HEAD requests are cacheable.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'HEAD');
+    $resp = new Google_Http_Request('http://localhost', 'HEAD');
     $resp->setResponseHttpCode('200');
     $resp->setResponseBody(null);
     $resp->setResponseHeaders(array(
@@ -70,7 +70,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertTrue($result);
 
     // Verify that Vary: * cannot get cached.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600, must-revalidate',
@@ -84,7 +84,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse($result);
 
     // Verify 201s cannot get cached.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('201');
     $resp->setResponseBody(null);
     $resp->setResponseHeaders(array(
@@ -97,7 +97,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse($result);
 
     // Verify pragma: no-cache.
-    $resp = new Google_Http_Request($this->getClient(), 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  'Wed, 11 Jan 2012 04:03:37 GMT',
@@ -110,7 +110,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse($result);
 
     // Verify Cache-Control: no-store.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  'Wed, 11 Jan 2012 04:03:37 GMT',
@@ -122,7 +122,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse($result);
 
     // Verify that authorized responses are not cacheable.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setRequestHeaders(array('Authorization' => 'Bearer Token'));
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
@@ -141,7 +141,7 @@ class ApiCacheParserTest extends BaseTest {
     $client = $this->getClient();
 
     // Expires 1 year in the future. Response is fresh.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  gmdate('D, d M Y H:i:s', $future) . ' GMT',
@@ -150,7 +150,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertFalse(Google_Http_CacheParser::isExpired($resp));
 
     // The response expires soon. Response is fresh.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  gmdate('D, d M Y H:i:s', $now + 2) . ' GMT',
@@ -160,7 +160,7 @@ class ApiCacheParserTest extends BaseTest {
 
     // Expired 1 year ago. Response is stale.
     $past = $now - (365 * 24 * 60 * 60);
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  gmdate('D, d M Y H:i:s', $past) . ' GMT',
@@ -169,7 +169,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertTrue(Google_Http_CacheParser::isExpired($resp));
 
     // Invalid expires header. Response is stale.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  '-1',
@@ -178,7 +178,7 @@ class ApiCacheParserTest extends BaseTest {
     $this->assertTrue(Google_Http_CacheParser::isExpired($resp));
 
     // The response expires immediately. G+ APIs do this. Response is stale.
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Expires' =>  gmdate('D, d M Y H:i:s', $now) . ' GMT',
@@ -194,7 +194,7 @@ class ApiCacheParserTest extends BaseTest {
     // Expires 1 year in the future, and contains the must-revalidate directive.
     // Don't revalidate. must-revalidate only applies to expired entries.
     $future = $now + (365 * 24 * 60 * 60);
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600, must-revalidate',
@@ -206,7 +206,7 @@ class ApiCacheParserTest extends BaseTest {
     // Contains the max-age=3600 directive, but was created 2 hours ago.
     // Must revalidate.
     $past = $now - (2 * 60 * 60);
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600',
@@ -218,7 +218,7 @@ class ApiCacheParserTest extends BaseTest {
     // Contains the max-age=3600 directive, and was created 600 seconds ago.
     // No need to revalidate, regardless of the expires header.
     $past = $now - (600);
-    $resp = new Google_Http_Request($client, 'http://localhost', 'GET');
+    $resp = new Google_Http_Request('http://localhost', 'GET');
     $resp->setResponseHttpCode('200');
     $resp->setResponseHeaders(array(
       'Cache-Control' => 'max-age=3600',

--- a/tests/general/ApiClientTest.php
+++ b/tests/general/ApiClientTest.php
@@ -29,7 +29,7 @@ class ApiClientTest extends BaseTest {
     $client = new Google_Client();
     $client->setAccessType('foo');
     $client->setDeveloperKey('foo');
-    $req = new Google_Http_Request($this->getClient(), 'http://foo.com');
+    $req = new Google_Http_Request('http://foo.com');
     $client->getAuth()->sign($req);
     $params = $req->getQueryParams();
     $this->assertEquals('foo', $params['key']);
@@ -38,12 +38,18 @@ class ApiClientTest extends BaseTest {
     $this->assertEquals("{\"access_token\":\"1\"}", $client->getAccessToken());
   }
 
-  public function testPrepareService() {
+  /**
+   * @expectedException Google_Auth_Exception
+   */
+  public function testPrepareInvalidScopes() {
     $client = new Google_Client();
 
     $scopes = $client->prepareScopes();
     $this->assertEquals("", $scopes);
+  }
 
+  public function testPrepareService() {
+    $client = new Google_Client();
     $client->setScopes(array("scope1", "scope2"));
     $scopes = $client->prepareScopes();
     $this->assertEquals("scope1 scope2", $scopes);
@@ -51,6 +57,12 @@ class ApiClientTest extends BaseTest {
     $client->setScopes(array("", "scope2"));
     $scopes = $client->prepareScopes();
     $this->assertEquals(" scope2", $scopes);
+    
+    $client->setScopes("scope2");
+    $client->addScope("scope3");
+    $client->addScope(array("scope4", "scope5"));
+    $scopes = $client->prepareScopes();
+    $this->assertEquals("scope2 scope3 scope4 scope5", $scopes);
 
     $client->setClientId('test1');
     $client->setRedirectUri('http://localhost/');

--- a/tests/general/ApiMediaFileUploadTest.php
+++ b/tests/general/ApiMediaFileUploadTest.php
@@ -24,7 +24,7 @@ require_once 'Google/Http/MediaFileUpload.php';
 class ApiMediaFileUploadTest extends BaseTest {
   public function testMediaFile() {
     $client = $this->getClient();
-    $request = new Google_Http_Request($client, 'http://www.example.com', 'POST');
+    $request = new Google_Http_Request('http://www.example.com', 'POST');
     $media = new Google_Http_MediaFileUpload($client, $request, 'image/png', base64_decode('data:image/png;base64,a'));
 
     $this->assertEquals(0, $media->getProgress());
@@ -33,7 +33,7 @@ class ApiMediaFileUploadTest extends BaseTest {
 
   public function testGetUploadType() {
       $client = $this->getClient();
-      $request = new Google_Http_Request($client, 'http://www.example.com', 'POST');
+      $request = new Google_Http_Request('http://www.example.com', 'POST');
 
       // Test resumable upload
       $media = new Google_Http_MediaFileUpload($client, $request, 'image/png', 'a', true);
@@ -57,19 +57,19 @@ class ApiMediaFileUploadTest extends BaseTest {
       $data = 'foo';
       
       // Test data *only* uploads.
-      $request = new Google_Http_Request($client, 'http://www.example.com', 'POST');
+      $request = new Google_Http_Request('http://www.example.com', 'POST');
       $media = new Google_Http_MediaFileUpload($client, $request, 'image/png', $data, false);
       $this->assertEquals($data, $request->getPostBody());
     
       // Test resumable (meta data) - we want to send the metadata, not the app data.
-      $request = new Google_Http_Request($client, 'http://www.example.com', 'POST');
+      $request = new Google_Http_Request('http://www.example.com', 'POST');
       $reqData = json_encode("hello");
       $request->setPostBody($reqData);
       $media = new Google_Http_MediaFileUpload($client, $request, 'image/png', $data, true);
       $this->assertEquals(json_decode($reqData), $request->getPostBody());
     
       // Test multipart - we are sending encoded meta data and post data
-      $request = new Google_Http_Request($client, 'http://www.example.com', 'POST');
+      $request = new Google_Http_Request('http://www.example.com', 'POST');
       $reqData = json_encode("hello");
       $request->setPostBody($reqData);
       $media = new Google_Http_MediaFileUpload($client, $request, 'image/png', $data, false);

--- a/tests/general/ApiOAuth2Test.php
+++ b/tests/general/ApiOAuth2Test.php
@@ -36,7 +36,7 @@ class ApiOAuth2Test extends BaseTest {
     $client->setApprovalPrompt('force');
     $client->setRequestVisibleActions('http://foo');
 
-    $req = new Google_Http_Request($client, 'http://localhost');
+    $req = new Google_Http_Request('http://localhost');
     $req = $oauth->sign($req);
 
     $this->assertEquals('http://localhost?key=devKey', $req->getUrl());

--- a/tests/general/AuthTest.php
+++ b/tests/general/AuthTest.php
@@ -210,7 +210,7 @@ class AuthTest extends BaseTest {
     $oldAuth = $this->getClient()->getAuth();
     $this->getClient()->setAuth($noAuth);
     $this->getClient()->setDeveloperKey(null);
-    $req = new Google_Http_Request($this->getClient(), "http://example.com");
+    $req = new Google_Http_Request("http://example.com");
 
     $resp = $noAuth->sign($req);
     try {

--- a/tests/general/IoTest.php
+++ b/tests/general/IoTest.php
@@ -53,7 +53,7 @@ class IoTest extends BaseTest {
     $url = "http://www.googleapis.com";
     // Create a cacheable request/response.
     // Should not be revalidated.
-    $cacheReq = new Google_Http_Request($client, $url, "GET");
+    $cacheReq = new Google_Http_Request($url, "GET");
     $cacheReq->setRequestHeaders(array(
       "Accept" => "*/*",
     ));
@@ -71,7 +71,7 @@ class IoTest extends BaseTest {
     $io->setCachedRequest($cacheReq);
 
     // Execute the same mock request, and expect a cache hit.
-    $res = $io->makeRequest(new Google_Http_Request($client, $url, "GET"));
+    $res = $io->makeRequest(new Google_Http_Request($url, "GET"));
     $this->assertEquals("{\"a\": \"foo\"}", $res->getResponseBody());
     $this->assertEquals(200, $res->getResponseHttpCode());
   }
@@ -80,7 +80,7 @@ class IoTest extends BaseTest {
     $url = "http://www.googleapis.com/protected/resource";
 
     // Create a cacheable request/response, but it should not be cached.
-    $cacheReq = new Google_Http_Request($client, $url, "GET");
+    $cacheReq = new Google_Http_Request($url, "GET");
     $cacheReq->setRequestHeaders(array(
       "Accept" => "*/*",
       "Authorization" => "Bearer Foo"
@@ -131,7 +131,7 @@ class IoTest extends BaseTest {
   }
 
   public function processEntityRequest($io, $client) {
-    $req = new Google_Http_Request($client, "http://localhost.com");
+    $req = new Google_Http_Request("http://localhost.com");
     $req->setRequestMethod("POST");
 
     // Verify that the content-length is calculated.

--- a/tests/general/RequestTest.php
+++ b/tests/general/RequestTest.php
@@ -27,7 +27,7 @@ class RequestTest extends BaseTest {
   {
     $url = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my';
     $url2 = 'http://localhost:8080/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
-    $request = new Google_Http_Request($this->getClient(), $url);
+    $request = new Google_Http_Request($url);
     $request->setExpectedClass("Google_Client");
     $this->assertEquals(2, count($request->getQueryParams()));
     $request->setQueryParam("hi", "there");
@@ -37,10 +37,18 @@ class RequestTest extends BaseTest {
     $url3a = 'http://localhost:8080/foo/bar';
     $url3b = 'foo=a&foo=b&wowee=oh+my';
     $url3c = 'foo=a&foo=b&wowee=oh+my&hi=there';
-    $request = new Google_Http_Request($this->getClient(), $url3a."?".$url3b, "POST");
+    $request = new Google_Http_Request($url3a."?".$url3b, "POST");
     $request->setQueryParam("hi", "there");
     $request->maybeMoveParametersToBody();
     $this->assertEquals($url3a, $request->getUrl());
     $this->assertEquals($url3c, $request->getPostBody());
+    
+    $url4 = 'http://localhost:8080/upload/foo/bar?foo=a&foo=b&wowee=oh+my&hi=there';
+    $request = new Google_Http_Request($url);
+    $this->assertEquals(2, count($request->getQueryParams()));
+    $request->setQueryParam("hi", "there");
+    $base = $request->getBaseComponent();
+    $request->setBaseComponent($base . '/upload');
+    $this->assertEquals($url4, $request->getUrl());
   }
 }

--- a/tests/general/RestTest.php
+++ b/tests/general/RestTest.php
@@ -32,7 +32,7 @@ class RestTest extends BaseTest {
   public function testDecodeResponse() {
     $url = 'http://localhost';
     $client = $this->getClient();
-    $response = new Google_Http_Request($client, $url);
+    $response = new Google_Http_Request($url);
     $response->setResponseHttpCode(204);
     $decoded = $this->rest->decodeHttpResponse($response);
     $this->assertEquals(null, $decoded);
@@ -40,7 +40,7 @@ class RestTest extends BaseTest {
 
     foreach (array(200, 201) as $code) {
       $headers = array('foo', 'bar');
-      $response = new Google_Http_Request($client, $url, 'GET', $headers);
+      $response = new Google_Http_Request($url, 'GET', $headers);
       $response->setResponseBody('{"a": 1}');
 
       $response->setResponseHttpCode($code);
@@ -48,7 +48,7 @@ class RestTest extends BaseTest {
       $this->assertEquals(array("a" => 1), $decoded);
     }
 
-    $response = new Google_Http_Request($client, $url);
+    $response = new Google_Http_Request($url);
     $response->setResponseHttpCode(500);
 
     $error = "";
@@ -65,7 +65,7 @@ class RestTest extends BaseTest {
   public function testDecodeEmptyResponse() {
     $url = 'http://localhost';
 
-    $response = new Google_Http_Request($this->getClient(), $url, 'GET', array());
+    $response = new Google_Http_Request($url, 'GET', array());
     $response->setResponseBody('{}');
 
     $response->setResponseHttpCode(200);


### PR DESCRIPTION
Auto scope addition has been removed. AddService remains in client
as a stub method until the templates are updated.

Request has been decoupled from client, so should now be serializable
without dependency. This required changing the deferred execution model
slightly.

Tests updated, and codesniff run.
