### PR TITLE
changing autoloader to use classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "php": ">=5.2.1"
     },
     "autoload": {
-        "psr-0": {
-            "Google": "src"
-        }
+        "classmap": [
+            "src/"
+        ]
     },
     "include-path": ["src/"]
 }


### PR DESCRIPTION
Since the file and class definition structure do not meet psr-0 standards, using a classmap for autoloading is a better option. With this change, people using the composer autoloader can instantiate sub classes, ex: Google_Service_Directory_User without having to previously included the Google/Service/Directory file.

The composer.json definition still has the include-path directive though because many class files have specific require statements in them, so they themselves do not use autoloading.

This pull request is a fix for issue #20
