### PR TITLE
Fix caching locking issue on Windows

### DIFF
--- a/src/Google/Cache/File.php
+++ b/src/Google/Cache/File.php
@@ -70,7 +70,7 @@ class Google_Cache_File extends Google_Cache_Abstract
       // We serialize the whole request object, since we don't only want the
       // responseContent but also the postBody used, headers, size, etc.
       $data = serialize($value);
-      $result = file_put_contents($storageFile, $data);
+      $result = fwrite($this->fh, $data);
       $this->unlock($storageFile);
     }
   }


### PR DESCRIPTION
Locking breaks caching on windows, as reported in #22.
Update to use fwrite. To be honest, this locking looks over the
top - I think we could strip it down significantly, so may be
a job for the future.
