### PR TITLE
Fixing Uploads

### DIFF
--- a/examples/simplefileupload.php
+++ b/examples/simplefileupload.php
@@ -46,11 +46,11 @@ $client = new Google_Client();
 $client->setClientId($client_id);
 $client->setClientSecret($client_secret);
 $client->setRedirectUri($redirect_uri);
-$client->addScope("https://www.googleapis.com/auth/drive")
+$client->addScope("https://www.googleapis.com/auth/drive");
 $service = new Google_Service_Drive($client);
 
 if (isset($_REQUEST['logout'])) {
-  unset($_SESSION['upload_token ']);
+  unset($_SESSION['upload_token']);
 }
 
 if (isset($_GET['code'])) {
@@ -85,7 +85,7 @@ if ($client->getAccessToken()) {
       )
   );
 
-  // Now lets try and send a the metadata as well using multipart!
+  // Now lets try and send the metadata as well using multipart!
   $file = new Google_Service_Drive_DriveFile();
   $file->setTitle("Hello World!");
   $result2 = $service->files->insert(

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -40,9 +40,6 @@ class Google_Http_REST
    */
   public static function execute(Google_Client $client, Google_Http_Request $req)
   {
-    if (!$req->getBaseComponent()) {
-      $req->setBaseComponent($client->getBasePath());
-    }
     $httpRequest = $client->getIo()->makeRequest($req);
     $httpRequest->setExpectedClass($req->getExpectedClass());
     return self::decodeHttpResponse($httpRequest);

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -164,6 +164,7 @@ class Google_Service_Resource
         null,
         $postBody
     );
+    $httpRequest->setBaseComponent($this->client->getBasePath());
 
     if ($postBody) {
       $contentTypeHeader = array();

--- a/tests/general/RequestTest.php
+++ b/tests/general/RequestTest.php
@@ -34,6 +34,12 @@ class RequestTest extends BaseTest {
     $this->assertEquals($url2, $request->getUrl());
     $this->assertEquals("Google_Client", $request->getExpectedClass());
     
+    $urlPath = "/foo/bar";
+    $request = new Google_Http_Request($urlPath);
+    $this->assertEquals($urlPath, $request->getUrl());
+    $request->setBaseComponent("http://example.com");
+    $this->assertEquals("http://example.com" . $urlPath, $request->getUrl());
+    
     $url3a = 'http://localhost:8080/foo/bar';
     $url3b = 'foo=a&foo=b&wowee=oh+my';
     $url3c = 'foo=a&foo=b&wowee=oh+my&hi=there';


### PR DESCRIPTION
File uploads were failing because of where the base component was defined.
The last PR made that automatically added the REST execute - this makes it
dependent on the caller. Since the main source of path only URLs is the Service
classes, we make the Resource class (which they use for calls) specify the
base component, which resolves the upload issue.

Should resolve #30
