### PR TITLE
Fix to the parseQuery() method

### DIFF
--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -384,10 +384,10 @@ class Google_Http_Request
       list($key, $value) = explode('=', $part, 2);
       $value = urldecode($value);
       if (isset($return[$key])) {
-          if (!is_array($return[$key])) {
-              $return[$key] = array($return[$key]);
-          }
-          $return[$key][] = $value;
+        if (!is_array($return[$key])) {
+          $return[$key] = array($return[$key]);
+        }
+        $return[$key][] = $value;
       } else {
         $return[$key] = $value;
       }


### PR DESCRIPTION
When parsing a query string with more than two variables with the same name, the array is not well formed.
Then when this parsed query is used on the buildQuery() method, the urlencode function throws an error.

I add a check to see if $return[$key] is not an array. Only in this case we know that its a string and we need to convert it to an array.

You can simulate this by adding 3 or more dimensions to the query.

Hope it helps.
Thanks. 
