### PR TITLE
changed [] with array()

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -77,7 +77,7 @@ class Google_IO_Curl extends Google_IO_Abstract
     $responseHeaders = $this->getHttpResponseHeaders($responseHeaderString);
     $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
-    return [$responseBody, $responseHeaders, $responseCode];
+    return array($responseBody, $responseHeaders, $responseCode);
   }
 
   /**


### PR DESCRIPTION
closes #95
array initialization with "[]" requires PHP 5.4. Since lib supports PHP 5.2.1 it should be "array()"
