### PR TITLE
added proper collection_key for Google_Service_Bigquery_JobStatus

### DIFF
--- a/src/Google/Service/Bigquery.php
+++ b/src/Google/Service/Bigquery.php
@@ -2382,6 +2382,7 @@ class Google_Service_Bigquery_JobStatus extends Google_Collection
   protected $errorResultDataType = '';
   protected $errorsType = 'Google_Service_Bigquery_ErrorProto';
   protected $errorsDataType = 'array';
+  protected $collection_key = 'errors';
   public $state;
 
   public function setErrorResult(Google_Service_Bigquery_ErrorProto $errorResult)


### PR DESCRIPTION
By having this, we can use the Countable operations on the object like:

``` php
echo $status->count();
```
