### PR TITLE
Fix Google_IO_{Curl,Stream} setOptions

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -93,7 +93,7 @@ class Google_IO_Curl extends Google_IO_Abstract
    */
   public function setOptions($options)
   {
-    $this->options = array_merge($this->options, $options);
+    $this->options += $options;
   }
 
   /**

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -135,7 +135,7 @@ class Google_IO_Stream extends Google_IO_Abstract
    */
   public function setOptions($options)
   {
-    $this->options = array_merge($this->options, $options);
+    $this->options += $options;
   }
 
   /**


### PR DESCRIPTION
Fix Google_IO_{Curl,Stream} setOptions
- array_merge fores reindex on associative array, nuking the keys. + (union) operator for arrays specifically does the intended behavior of preserving the keys.

This took me for a bit of a loop -- I had upgraded our google-api-php-client lib and was getting an error with curl_setopt when calling `setOptions(array(CURLOPT_PROXY => '...'));`

Doing a var_dump() on $this->options revealed the keys had been turned into indexes by array_merge. I have verified everything works as desired when using the + (union) operator.

This blog post explains it well:
http://unix0.wordpress.com/2012/01/08/php-array_merge-vs-plus-union-operator/
