### PR TITLE
Make sure Google_IO_{Curl,Stream} setOptions allows overriding defaults

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -96,7 +96,7 @@ class Google_IO_Curl extends Google_IO_Abstract
    */
   public function setOptions($options)
   {
-    $this->options += $options;
+    $this->options = $options + $this->options;
   }
 
   /**

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -135,7 +135,7 @@ class Google_IO_Stream extends Google_IO_Abstract
    */
   public function setOptions($options)
   {
-    $this->options += $options;
+    $this->options = $options + $this->options;
   }
 
   /**


### PR DESCRIPTION
Adjusting setOptions() per Hector Virgen's points. The previous way would not allow overriding that which was already set in $this->options -- writing it this way ensures $options' contents take precedence.
