### PR TITLE
Automatically run tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 
 php:
+  # Can't test against 5.2; openssl is not available:
+  # http://docs.travis-ci.com/user/languages/php/#PHP-installation
+  - 5.3
+  - 5.4
   - 5.5
 
-before_script: 
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
+before_script:
+  - composer install
 
 script: 
   - cd tests ; phpunit .

--- a/tests/pagespeed/PageSpeedTest.php
+++ b/tests/pagespeed/PageSpeedTest.php
@@ -25,6 +25,7 @@ class PageSpeedTest extends BaseTest {
   }
 
   public function testPageSpeed() {
+    $this->checkToken();
     $psapi = $this->service->pagespeedapi;
     $result = $psapi->runpagespeed('http://code.google.com');
     $this->assertArrayHasKey('kind', $result);

--- a/tests/plus/PlusTest.php
+++ b/tests/plus/PlusTest.php
@@ -35,6 +35,7 @@ class PlusTest extends BaseTest {
   }
 
   public function testGetPerson() {
+    $this->checkToken();
     $person = $this->plus->people->get("118051310819094153327");
     $this->assertArrayHasKey('kind', $person);
     $this->assertArrayHasKey('displayName', $person);
@@ -43,6 +44,7 @@ class PlusTest extends BaseTest {
   }
 
   public function testListActivities() {
+    $this->checkToken();
     $activities = $this->plus->activities
         ->listActivities("118051310819094153327", "public");
     


### PR DESCRIPTION
Adds simple `.travis.yml` for running tests via Travis.

A few tests are disabled because they require a real API key; not sure of a good way to deal with this.

Running composer to get phpunit is not actually required since the Travis versions of PHP come with phpunit, and (right now) they run the tests successfully. However, it's probably better to be sure of the version we're getting.
