### PR TITLE
Add Travis CI build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/google/google-api-php-client.svg)](https://travis-ci.org/google/google-api-php-client)
+
 # Google APIs Client Library for PHP #
 
 ## Description ##


### PR DESCRIPTION
This shows the status of master, so it's going to show as "unknown" until merged. (Or master gets built in some other way.)
