### PR TITLE
Set a default value for array and map types

### DIFF
--- a/src/Google/Model.php
+++ b/src/Google/Model.php
@@ -48,7 +48,8 @@ class Google_Model implements ArrayAccess
     if (isset($this->$keyTypeName) && !isset($this->processed[$key])) {
       if (isset($this->modelData[$key])) {
         $val = $this->modelData[$key];
-      } else if (isset($this->$keyDataType) && ($this->$keyDataType == 'array' || $this->$keyDataType == 'map')) {
+      } else if (isset($this->$keyDataType) &&
+          ($this->$keyDataType == 'array' || $this->$keyDataType == 'map')) {
         $val = array();
       } else {
         $val = null;


### PR DESCRIPTION
If a response has a property foo that is an optional collection then doing `$model->getFoo()` when the property is not in the response causes

`Notice: Undefined index: foo in ~/google-api-php-client/src/Google/Model.php on line 76`

Given that we know about the collection we can default to an empty array instead.

The code here is a little hairy, please make sure I haven't done anything stupid.

(My editor added a bonus whitespace fix too)
