### PR TITLE
Prevent PHP warnings if creation/expiry dates not known for access token

### DIFF
--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -367,7 +367,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
    */
   public function isAccessTokenExpired()
   {
-    if (!$this->token) {
+    if (!$this->token || !isset($this->token['created'])) {
       return true;
     }
 


### PR DESCRIPTION
If $client->setAccessToken() is called with a token that was not obtained via this SDK, then later operations which call Google_Auth_OAuth2::isAccessTokenExpired() cause 2 PHP warnings. This check prevents those warnings.

The use case for using a token obtained from elsewhere is when migrating to this SDK from another solution, where a request token is stored and you don't want the user to be forced to re-authenticate upon an upgrade.
