### PR TITLE
Check curl_exec as well as curl_version

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -102,7 +102,7 @@ class Google_Client
     }
     
     if ($config->getIoClass() == Google_Config::USE_AUTO_IO_SELECTION) {
-      if (function_exists('curl_version')) {
+      if (function_exists('curl_version') && function_exists('curl_exec')) {
         $config->setIoClass("Google_Io_Curl");
       } else {
         $config->setIoClass("Google_Io_Stream");


### PR DESCRIPTION
I think I've seen cases where web hosts have got Curl installed, but disable it via disabling the function curl_exec (the function that actually causes network activity). In this case, the check for curl_version alone will give a misleading result. Hence this tweak.
