### PR TITLE
Set CURLOPT_URL before CURLOPT_CUSTOMREQUEST

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -54,6 +54,8 @@ class Google_IO_Curl extends Google_IO_Abstract
       curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);
     }
 
+    curl_setopt($curl, CURLOPT_URL, $request->getUrl());
+    
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getRequestMethod());
     curl_setopt($curl, CURLOPT_USERAGENT, $request->getUserAgent());
 
@@ -61,8 +63,6 @@ class Google_IO_Curl extends Google_IO_Abstract
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HEADER, true);
-
-    curl_setopt($curl, CURLOPT_URL, $request->getUrl());
 
     if ($request->canGzip()) {
       curl_setopt($curl, CURLOPT_ENCODING, 'gzip,deflate');


### PR DESCRIPTION
One of my users reports this PHP warning:
"Warning: Can't set CURLOPT_CUSTOMREQUEST before CURLOPT_URL in Google/IO/Curl.php
on line 57"

Hence, this tweak.
