### PR TITLE
Fix cURL proxy header miscalculation workaround

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -25,7 +25,7 @@ require_once 'Google/IO/Abstract.php';
 
 class Google_IO_Curl extends Google_IO_Abstract
 {
-  // hex for version 7.30.0
+  // cURL hex representation of version 7.30.0
   const NO_QUIRK_VERSION = 0x071E00;
 
   private $options = array();
@@ -123,7 +123,10 @@ class Google_IO_Curl extends Google_IO_Abstract
   }
 
   /**
-   * Determine whether "Connection Established" quirk is needed
+   * Test for the presence of a cURL header processing bug
+   *
+   * {@inheritDoc}
+   *
    * @return boolean
    */
   protected function needsQuirk()

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -157,13 +157,15 @@ class Google_IO_Stream extends Google_IO_Abstract
   }
 
   /**
-   * Determine whether "Connection Established" quirk is needed
+   * Test for the presence of a cURL header processing bug
+   *
+   * {@inheritDoc}
+   *
    * @return boolean
    */
   protected function needsQuirk()
   {
-      // Stream needs the special quirk
-      return true;
+    return false;
   }
 
   protected function getHttpResponseCode($response_headers)

--- a/tests/general/IoTest.php
+++ b/tests/general/IoTest.php
@@ -196,6 +196,9 @@ class IoTest extends BaseTest
 
   public function responseChecker($io)
   {
+    $curlVer = curl_version();
+    $hasQuirk = $curlVer['version_number'] < Google_IO_Curl::NO_QUIRK_VERSION;
+
     $rawHeaders = "HTTP/1.1 200 OK\r\n"
         . "Expires: Sun, 22 Jan 2012 09:00:56 GMT\r\n"
         . "Date: Sun, 22 Jan 2012 09:00:56 GMT\r\n"
@@ -218,6 +221,11 @@ class IoTest extends BaseTest
     $rawHeaders = Google_IO_Abstract::CONNECTION_ESTABLISHED
         . "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n";
     $headersSize = strlen($rawHeaders);
+    // If we have a broken cURL version we have to simulate it to get the
+    // correct test result.
+    if ($hasQuirk && get_class($io) === 'Google_IO_Curl') {
+        $headersSize -= strlen(Google_IO_Abstract::CONNECTION_ESTABLISHED);
+    }
     $rawBody = "{}";
 
     $rawResponse = "$rawHeaders\r\n$rawBody";


### PR DESCRIPTION
**This should be (but does not need to be) merged after #189**

If a proxy header is detected and a buggy cURL version is found, we currently strip the proxy header and reduce the header size by the same amount. This is problematic because the actual cURL bug is that the proxy header size **was not taken into account in the first place**. Therefore, when the header size is reduced on old versions of cURL, the newly calculated header size is too small, and the subsequent calculations are wrong.

Secondly, the `Google_IO_Curl` version constant for the cURL workaround is not correct, the fix version is `7.30.0` (`0x071E00`) [(search for "corrected proxy header response headers count" in the changelog)](http://curl.haxx.se/changes.html), not `7.31.0` (`0x071F00`).

This PR fixes these related problems with the cURL workaround, and retains backward compatibility with the API that was introduced to solve the problem in the first place.
