### PR TITLE
Enable memcached and APC tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+services:
+  - memcached
+
+env:
+  - MEMCACHE_HOST=127.0.0.1 MEMCACHE_PORT=11211
+
 php:
   # Can't test against 5.2; openssl is not available:
   # http://docs.travis-ci.com/user/languages/php/#PHP-installation
@@ -9,6 +15,10 @@ php:
 
 before_script:
   - composer install
+  - echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - phpenv version-name | grep ^5.[34] && echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
+  - phpenv version-name | grep ^5.[34] && echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
 
-script: 
+script:
   - cd tests ; phpunit .

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -29,10 +29,9 @@ class BaseTest extends PHPUnit_Framework_TestCase {
     // Fill in a token JSON here and you can test the oauth token 
     // requiring functions.
     // $this->token = '';
-    
-    // Fill in memcache values to test the memcache class.
-    // $this->memcacheHost = '127.0.0.1';
-    // $this->memcachePort = '11211';
+
+    $this->memcacheHost = getenv('MEMCACHE_HOST') ? getenv('MEMCACHE_HOST') : null;
+    $this->memcachePort = getenv('MEMCACHE_PORT') ? getenv('MEMCACHE_PORT') : null;
   }
   
   public function getClient() {

--- a/tests/general/ApiClientTest.php
+++ b/tests/general/ApiClientTest.php
@@ -118,7 +118,7 @@ class ApiClientTest extends BaseTest {
   }
 
   public function testAppEngineAutoConfig() {
-    if (!function_exists('memcache_connect')) {
+    if (!class_exists("Memcached")) {
       $this->markTestSkipped('Test requires memcache');
     }
     $_SERVER['SERVER_SOFTWARE'] = 'Google App Engine';


### PR DESCRIPTION
Enables 4 more tests on Travis. (Only 3 more on PHP 5.5; it doesn't have APC.)
