### PR TITLE
Adding branch alias for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
             "src/"
         ]
     },
-    "include-path": ["src/"]
+    "include-path": ["src/"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Adding branch alias to prevent version conflict when using latest master version. See [Aliases](https://getcomposer.org/doc/articles/aliases.md) for more information.
