### PR TITLE
Updated the required paths to be more command line friendly

### DIFF
--- a/src/Google/Auth/Abstract.php
+++ b/src/Google/Auth/Abstract.php
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Http/Request.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
 
 /**
  * Abstract class for the Authentication in the API client

--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -22,8 +22,8 @@
  */
 use google\appengine\api\app_identity\AppIdentityService;
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Http/Request.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
 
 /**
  * Authentication via the Google App Engine App Identity service.

--- a/src/Google/Auth/AssertionCredentials.php
+++ b/src/Google/Auth/AssertionCredentials.php
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/OAuth2.php";
-require_once "Google/Signer/P12.php";
-require_once "Google/Utils.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/OAuth2.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Signer/P12.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Utils.php";
 
 /**
  * Credentials object used for OAuth 2.0 Signed JWT assertion grants.

--- a/src/Google/Auth/Exception.php
+++ b/src/Google/Auth/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Exception.php";
 
 class Google_Auth_Exception extends Google_Exception
 {

--- a/src/Google/Auth/LoginTicket.php
+++ b/src/Google/Auth/LoginTicket.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/Exception.php";
 
 /**
  * Class to hold information about an authenticated login.

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Auth/AssertionCredentials.php";
-require_once "Google/Auth/Exception.php";
-require_once "Google/Auth/LoginTicket.php";
-require_once "Google/Client.php";
-require_once "Google/Http/Request.php";
-require_once "Google/Utils.php";
-require_once "Google/Verifier/Pem.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/AssertionCredentials.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/LoginTicket.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Client.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Utils.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Verifier/Pem.php";
 
 /**
  * Authentication class that deals with the OAuth 2 web-server authentication flow

--- a/src/Google/Auth/Simple.php
+++ b/src/Google/Auth/Simple.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-require_once "Google/Auth/Abstract.php";
-require_once "Google/Http/Request.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Auth/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
 
 /**
  * Simple API access implementation. Can either be used to make requests

--- a/src/Google/Cache/Apc.php
+++ b/src/Google/Cache/Apc.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
  
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Exception.php";
 
 /**
  * A persistent storage class based on the APC cache, which is not

--- a/src/Google/Cache/Exception.php
+++ b/src/Google/Cache/Exception.php
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once "Google/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Exception.php";
 
 class Google_Cache_Exception extends Google_Exception
 {

--- a/src/Google/Cache/File.php
+++ b/src/Google/Cache/File.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Exception.php";
 
 /*
  * This class implements a basic on disk storage. While that does

--- a/src/Google/Cache/Memcache.php
+++ b/src/Google/Cache/Memcache.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Exception.php";
 
 /**
  * A persistent storage class based on the memcache, which is not

--- a/src/Google/Cache/Null.php
+++ b/src/Google/Cache/Null.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-require_once "Google/Cache/Abstract.php";
-require_once "Google/Cache/Exception.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Abstract.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Cache/Exception.php";
 
 /**
  * A blank storage class, for cases where caching is not

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -15,17 +15,17 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/AssertionCredentials.php';
-require_once 'Google/Cache/File.php';
-require_once 'Google/Cache/Memcache.php';
-require_once 'Google/Config.php';
-require_once 'Google/Collection.php';
-require_once 'Google/Exception.php';
-require_once 'Google/IO/Curl.php';
-require_once 'Google/IO/Stream.php';
-require_once 'Google/Model.php';
-require_once 'Google/Service.php';
-require_once 'Google/Service/Resource.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Auth/AssertionCredentials.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Cache/File.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Cache/Memcache.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Config.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Collection.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Exception.php';
+require_once dirname(dirname(__FILE__)) . '/Google/IO/Curl.php';
+require_once dirname(dirname(__FILE__)) . '/Google/IO/Stream.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Model.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Service.php';
+require_once dirname(dirname(__FILE__)) . '/Google/Service/Resource.php';
 
 /**
  * The Google API Client

--- a/src/Google/Collection.php
+++ b/src/Google/Collection.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Google/Model.php";
+require_once dirname(dirname(__FILE__)) . "/Google/Model.php";
 
 /**
  * Extension to the regular Google_Model that automatically

--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/REST.php';
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Client.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/REST.php";
 
 /**
  * @author Chirag Shah <chirags@google.com>

--- a/src/Google/Http/CacheParser.php
+++ b/src/Google/Http/CacheParser.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Http/Request.php';
+require_once dirname(dirname(dirname(__FILE__))) . "/Google/Http/Request.php";
 
 /**
  * Implement the caching directives specified in rfc2616. This

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Exception.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/REST.php';
-require_once 'Google/Utils.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Client.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/Request.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/REST.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Utils.php';
 
 /**
  * @author Chirag Shah <chirags@google.com>

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Service/Exception.php';
-require_once 'Google/Utils/URITemplate.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Client.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/Request.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Service/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Utils/URITemplate.php';
 
 /**
  * This class implements the RESTful transport of apiServiceRequest()'s

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Utils.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Utils.php';
 
 /**
  * HTTP Request to be executed by IO classes. Upon execution, the

--- a/src/Google/IO/Abstract.php
+++ b/src/Google/IO/Abstract.php
@@ -19,10 +19,10 @@
  * Abstract IO base class
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/IO/Exception.php';
-require_once 'Google/Http/CacheParser.php';
-require_once 'Google/Http/Request.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Client.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/IO/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/CacheParser.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/Request.php';
 
 abstract class Google_IO_Abstract
 {

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -21,7 +21,7 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once 'Google/IO/Abstract.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/IO/Abstract.php';
 
 class Google_IO_Curl extends Google_IO_Abstract
 {

--- a/src/Google/IO/Exception.php
+++ b/src/Google/IO/Exception.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once 'Google/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Exception.php';
 
 class Google_IO_Exception extends Google_Exception
 {

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -21,7 +21,7 @@
  * @author Stuart Langley <slangley@google.com>
  */
 
-require_once 'Google/IO/Abstract.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/IO/Abstract.php';
 
 class Google_IO_Stream extends Google_IO_Abstract
 {

--- a/src/Google/Service/Exception.php
+++ b/src/Google/Service/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'Google/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Exception.php';
 
 class Google_Service_Exception extends Google_Exception
 {

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-require_once 'Google/Client.php';
-require_once 'Google/Exception.php';
-require_once 'Google/Utils.php';
-require_once 'Google/Http/Request.php';
-require_once 'Google/Http/MediaFileUpload.php';
-require_once 'Google/Http/REST.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Client.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Utils.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/Request.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/MediaFileUpload.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Http/REST.php';
 
 /**
  * Implements the actual methods/resources of the discovered Google API using magic function

--- a/src/Google/Signer/P12.php
+++ b/src/Google/Signer/P12.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Signer/Abstract.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Auth/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Signer/Abstract.php';
 
 /**
  * Signs data.

--- a/src/Google/Verifier/Pem.php
+++ b/src/Google/Verifier/Pem.php
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
  
-require_once 'Google/Auth/Exception.php';
-require_once 'Google/Verifier/Abstract.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Auth/Exception.php';
+require_once dirname(dirname(dirname(__FILE__))) . '/Google/Verifier/Abstract.php';
 
 /**
  * Verifies signatures using PEM encoded certificates.


### PR DESCRIPTION
I had some trouble with regard to the file paths while writing a command line based script to access Big Query. CLI and relative paths aren't really friendly so I updated the paths tpo depend on the more reliable dirname(**FILE**) instead. Worked like a charm and there is hardly any code change and even less chance of future conflict.
