### PR TITLE
distinguish memcache key when array of scopes are used.

### DIFF
--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -55,7 +55,13 @@ class Google_Auth_AppIdentity extends Google_Auth_Abstract
     if (!$this->token) {
       $this->token = AppIdentityService::getAccessToken($scopes);
       if ($this->token) {
-        $memcache->set(self::CACHE_PREFIX . $scopes, $this->token, self::CACHE_LIFETIME);
+        $memcache_key = self::CACHE_PREFIX;
+        if (is_string($scopes)) {
+          $memcache_key .= $scopes;
+        } else if (is_array($scopes)) {
+          $memcache_key .= implode(":", $scopes);
+        }
+        $memcache->set($memcache_key, $this->token, self::CACHE_LIFETIME);
       }
     }
     $this->tokenScopes = $scopes;


### PR DESCRIPTION
Previously the memcache key would be "Google_Auth_AppIdentity::Array"
when an array of scopes was passed to AppIdentity->authenticateForScope.
This would causees the token to be overwritten when multiple
Google_Auth_AppIdentity were used with multiple scopes. The fix is to
expand the array of scopes into a string creating a unique key.
