### PR TITLE
Mod $filteringReasonsDataType in AdExchangeBuyer

### DIFF
--- a/src/Google/Service/AdExchangeBuyer.php
+++ b/src/Google/Service/AdExchangeBuyer.php
@@ -933,7 +933,7 @@ class Google_Service_AdExchangeBuyer_Creative extends Google_Collection
   protected $disapprovalReasonsType = 'Google_Service_AdExchangeBuyer_CreativeDisapprovalReasons';
   protected $disapprovalReasonsDataType = 'array';
   protected $filteringReasonsType = 'Google_Service_AdExchangeBuyer_CreativeFilteringReasons';
-  protected $filteringReasonsDataType = '';
+  protected $filteringReasonsDataType = 'array';
   public $height;
   public $kind;
   public $productCategories;


### PR DESCRIPTION
Changed $filteringReasonsDataType from '' to 'array' in AdExchangeBuyer.php. Without it the Model.php won't know about that object throwing a Notice and no filtering result is returned.
