### PR TITLE
Fix reference to Google_IO_Abstract (wrong case)

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -195,9 +195,9 @@ class Google_Client
 
   /**
    * Set the IO object
-   * @param Google_Io_Abstract $auth
+   * @param Google_IO_Abstract $auth
    */
-  public function setIo(Google_Io_Abstract $io)
+  public function setIo(Google_IO_Abstract $io)
   {
     $this->config->setIoClass(get_class($io));
     $this->io = $io;


### PR DESCRIPTION
This was causing phpunit to fail. The class is properly named Google_IO_Abstract not Google_Io_Abstract. I could not find any other "Google_Io" refs in the code.
