### PR TITLE
Stores error text in separate variable

### DIFF
--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -112,15 +112,15 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
     } else {
       $decodedResponse = json_decode($response->getResponseBody(), true);
       if ($decodedResponse != null && $decodedResponse['error']) {
-        $decodedResponse = $decodedResponse['error'];
+        $errorText = $decodedResponse['error'];
         if (isset($decodedResponse['error_description'])) {
-          $decodedResponse .= ": " . $decodedResponse['error_description'];
+          $errorText .= ": " . $decodedResponse['error_description'];
         }
       }
       throw new Google_Auth_Exception(
           sprintf(
               "Error fetching OAuth2 access token, message: '%s'",
-              $decodedResponse
+              $errorText
           ),
           $response->getResponseHttpCode()
       );


### PR DESCRIPTION
Fixes #350 by storing our error text in the $errorText variable, then generating the error from this new location.
