### PR TITLE
Force SSL negociation to use last TLS

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -61,6 +61,7 @@ class Google_IO_Curl extends Google_IO_Abstract
 
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, false);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
+    curl_setopt($curl, CURLOPT_SSLVERSION, 1);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($curl, CURLOPT_HEADER, true);
 


### PR DESCRIPTION
Since yesterday, calling the API generates loads of "SSL routines:SSL3_GET_RECORD:wrong version number" as well as "SSL routines:SSL3_GET_RECORD:decryption failed or bad record mac". 

We figured it could be coming from Google deprecating SSL v3. 
Using CURLOPT_SSLVERSION to set the remote SSL protocol version to TLSv1 worked for us.
