### PR TITLE
Changed rows in google analytics service gadata to default as an array

### DIFF
--- a/src/Google/Service/Analytics.php
+++ b/src/Google/Service/Analytics.php
@@ -6431,7 +6431,7 @@ class Google_Service_Analytics_GaData extends Google_Collection
   protected $profileInfoDataType = '';
   protected $queryType = 'Google_Service_Analytics_GaDataQuery';
   protected $queryDataType = '';
-  public $rows;
+  public $rows = array();
   public $sampleSize;
   public $sampleSpace;
   public $selfLink;


### PR DESCRIPTION
It seems from my use of the Google Analytics API that most of the time you are dealing with an array with the `rows` property and that in some scenarios there are no rows and it is a null which is more of a pain to deal with and by using an array it would make it more consistent and less error prone as most of my code is trying to loop through rows and is expecting arrays.

What do you think?
