### PR TITLE
Suppress `E_STRICT` errors when testing.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting(E_ALL & ~E_STRICT);
 set_include_path(
     dirname(__FILE__) . PATH_SEPARATOR .
     dirname(dirname(__FILE__)) . "/src". PATH_SEPARATOR .


### PR DESCRIPTION
This should get travis passing again.
