### PR TITLE
Add a PSR-3 style logging system that should be compatible with PHP 5.2+

### DIFF
--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -92,6 +92,9 @@ class Google_Auth_AppIdentity extends Google_Auth_Abstract
       // No token, so nothing to do.
       return $request;
     }
+
+    $this->client->getLogger()->debug('App Identity authentication');
+
     // Add the OAuth2 header to the request
     $request->setRequestHeaders(
         array('Authorization' => 'Bearer ' . $this->token['access_token'])

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -233,16 +233,20 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       if ($this->assertionCredentials) {
         $this->refreshTokenWithAssertion();
       } else {
+        $this->client->getLogger()->debug('OAuth2 access token expired');
         if (! array_key_exists('refresh_token', $this->token)) {
-            throw new Google_Auth_Exception(
-                "The OAuth 2.0 access token has expired,"
-                ." and a refresh token is not available. Refresh tokens"
-                ." are not returned for responses that were auto-approved."
-            );
+          $error = "The OAuth 2.0 access token has expired,"
+                  ." and a refresh token is not available. Refresh tokens"
+                  ." are not returned for responses that were auto-approved.";
+
+          $this->client->getLogger()->error($error);
+          throw new Google_Auth_Exception($error);
         }
         $this->refreshToken($this->token['refresh_token']);
       }
     }
+
+    $this->client->getLogger()->debug('OAuth2 authentication');
 
     // Add the OAuth2 header to the request
     $request->setRequestHeaders(
@@ -295,6 +299,7 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
       }
     }
 
+    $this->client->getLogger()->debug('OAuth2 access token expired');
     $this->refreshTokenRequest(
         array(
           'grant_type' => 'assertion',
@@ -314,6 +319,14 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
 
   private function refreshTokenRequest($params)
   {
+    if (isset($params['assertion'])) {
+      $this->client->getLogger()->info(
+          'OAuth2 access token refresh with Signed JWT assertion grants.'
+      );
+    } else {
+      $this->client->getLogger()->info('OAuth2 access token refresh');
+    }
+
     $http = new Google_Http_Request(
         self::OAUTH2_TOKEN_URI,
         'POST',

--- a/src/Google/Auth/Simple.php
+++ b/src/Google/Auth/Simple.php
@@ -54,6 +54,9 @@ class Google_Auth_Simple extends Google_Auth_Abstract
   {
     $key = $this->client->getClassConfig($this, 'developer_key');
     if ($key) {
+      $this->client->getLogger()->debug(
+          'Simple API Access developer key authentication'
+      );
       $request->setQueryParam('key', $key);
     }
     return $request;

--- a/src/Google/Cache/Apc.php
+++ b/src/Google/Cache/Apc.php
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
 /**
@@ -27,11 +27,21 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
  */
 class Google_Cache_Apc extends Google_Cache_Abstract
 {
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (! function_exists('apc_add') ) {
-      throw new Google_Cache_Exception("Apc functions not available");
+      $error = "Apc functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
   }
 
    /**
@@ -41,12 +51,26 @@ class Google_Cache_Apc extends Google_Cache_Abstract
   {
     $ret = apc_fetch($key);
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'APC cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'APC cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -55,10 +79,21 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function set($key, $value)
   {
-    $rc = apc_store($key, array('time' => time(), 'data' => $value));
+    $var = array('time' => time(), 'data' => $value);
+    $rc = apc_store($key, $var);
+
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'APC cache set failed',
+          array('key' => $key, 'var' => $var)
+      );
       throw new Google_Cache_Exception("Couldn't store data");
     }
+
+    $this->client->getLogger()->debug(
+        'APC cache set',
+        array('key' => $key, 'var' => $var)
+    );
   }
 
   /**
@@ -67,6 +102,10 @@ class Google_Cache_Apc extends Google_Cache_Abstract
    */
   public function delete($key)
   {
+    $this->client->getLogger()->debug(
+        'APC cache delete',
+        array('key' => $key)
+    );
     apc_delete($key);
   }
 }

--- a/src/Google/Cache/Memcache.php
+++ b/src/Google/Cache/Memcache.php
@@ -34,11 +34,22 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
   private $host;
   private $port;
 
+  /**
+   * @var Google_Client the current client
+   */
+  private $client;
+
   public function __construct(Google_Client $client)
   {
     if (!function_exists('memcache_connect') && !class_exists("Memcached")) {
-      throw new Google_Cache_Exception("Memcache functions not available");
+      $error = "Memcache functions not available";
+
+      $client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
+
+    $this->client = $client;
+
     if ($client->isAppEngine()) {
       // No credentials needed for GAE.
       $this->mc = new Memcached();
@@ -47,11 +58,14 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $this->host = $client->getClassConfig($this, 'host');
       $this->port = $client->getClassConfig($this, 'port');
       if (empty($this->host) || (empty($this->port) && (string) $this->port != "0")) {
-        throw new Google_Cache_Exception("You need to supply a valid memcache host and port");
+        $error = "You need to supply a valid memcache host and port";
+
+        $client->getLogger()->error($error);
+        throw new Google_Cache_Exception($error);
       }
     }
   }
-  
+
   /**
    * @inheritDoc
    */
@@ -65,12 +79,26 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $ret = memcache_get($this->connection, $key);
     }
     if ($ret === false) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss',
+          array('key' => $key)
+      );
       return false;
     }
     if (is_numeric($expiration) && (time() - $ret['time'] > $expiration)) {
+      $this->client->getLogger()->debug(
+          'Memcache cache miss (expired)',
+          array('key' => $key, 'var' => $ret)
+      );
       $this->delete($key);
       return false;
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache hit',
+        array('key' => $key, 'var' => $ret)
+    );
+
     return $ret['data'];
   }
 
@@ -93,8 +121,18 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
       $rc = memcache_set($this->connection, $key, $data, false);
     }
     if ($rc == false) {
+      $this->client->getLogger()->error(
+          'Memcache cache set failed',
+          array('key' => $key, 'var' => $data)
+      );
+
       throw new Google_Cache_Exception("Couldn't store data in cache");
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache set',
+        array('key' => $key, 'var' => $data)
+    );
   }
 
   /**
@@ -109,11 +147,16 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       memcache_delete($this->connection, $key, 0);
     }
+
+    $this->client->getLogger()->debug(
+        'Memcache cache delete',
+        array('key' => $key)
+    );
   }
 
   /**
-   * Lazy initialiser for memcache connection. Uses pconnect for to take 
-   * advantage of the persistence pool where possible. 
+   * Lazy initialiser for memcache connection. Uses pconnect for to take
+   * advantage of the persistence pool where possible.
    */
   private function connect()
   {
@@ -128,9 +171,12 @@ class Google_Cache_Memcache extends Google_Cache_Abstract
     } else {
       $this->connection = memcache_pconnect($this->host, $this->port);
     }
-    
+
     if (! $this->connection) {
-      throw new Google_Cache_Exception("Couldn't connect to memcache server");
+      $error = "Couldn't connect to memcache server";
+
+      $this->client->getLogger()->error($error);
+      throw new Google_Cache_Exception($error);
     }
   }
 }

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -49,6 +49,11 @@ class Google_Client
   private $config;
 
   /**
+   * @var Google_Logger_Abstract $logger
+   */
+  private $logger;
+
+  /**
    * @var boolean $deferExecution
    */
   private $deferExecution = false;
@@ -213,6 +218,16 @@ class Google_Client
   {
     $this->config->setCacheClass(get_class($cache));
     $this->cache = $cache;
+  }
+
+  /**
+   * Set the Logger object
+   * @param Google_Logger_Abstract $logger
+   */
+  public function setLogger(Google_Logger_Abstract $logger)
+  {
+    $this->config->setLoggerClass(get_class($logger));
+    $this->logger = $logger;
   }
 
   /**
@@ -596,6 +611,18 @@ class Google_Client
       $this->cache = new $class($this);
     }
     return $this->cache;
+  }
+
+  /**
+   * @return Google_Logger_Abstract Logger implementation
+   */
+  public function getLogger()
+  {
+    if (!isset($this->logger)) {
+      $class = $this->config->getLoggerClass();
+      $this->logger = new $class($this);
+    }
+    return $this->logger;
   }
 
   /**

--- a/src/Google/Config.php
+++ b/src/Google/Config.php
@@ -44,6 +44,7 @@ class Google_Config
       'auth_class'    => 'Google_Auth_OAuth2',
       'io_class'      => self::USE_AUTO_IO_SELECTION,
       'cache_class'   => 'Google_Cache_File',
+      'logger_class'  => 'Google_Logger_Null',
 
       // Don't change these unless you're working against a special development
       // or testing environment.
@@ -53,6 +54,17 @@ class Google_Config
       'classes' => array(
         'Google_IO_Abstract' => array(
           'request_timeout_seconds' => 100,
+        ),
+        'Google_Logger_Abstract' => array(
+          'level' => 'debug',
+          'log_format' => "[%datetime%] %level%: %message% %context%\n",
+          'date_format' => 'd/M/Y:H:i:s O',
+          'allow_newlines' => true
+        ),
+        'Google_Logger_File' => array(
+          'file' => 'php://stdout',
+          'mode' => 0640,
+          'lock' => false,
         ),
         'Google_Http_Request' => array(
           // Disable the use of gzip on calls if set to true. Defaults to false.
@@ -149,6 +161,15 @@ class Google_Config
   }
 
   /**
+   * Return the configured logger class.
+   * @return string
+   */
+  public function getLoggerClass()
+  {
+    return $this->configuration['logger_class'];
+  }
+
+  /**
    * Return the configured Auth class.
    * @return string
    */
@@ -203,6 +224,22 @@ class Google_Config
           $this->configuration['classes'][$prev];
     }
     $this->configuration['cache_class'] = $class;
+  }
+
+  /**
+   * Set the logger class.
+   *
+   * @param $class string the class name to set
+   */
+  public function setLoggerClass($class)
+  {
+    $prev = $this->configuration['logger_class'];
+    if (!isset($this->configuration['classes'][$class]) &&
+        isset($this->configuration['classes'][$prev])) {
+      $this->configuration['classes'][$class] =
+          $this->configuration['classes'][$prev];
+    }
+    $this->configuration['logger_class'] = $class;
   }
 
   /**

--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -123,7 +123,7 @@ class Google_Http_Batch
           }
 
           try {
-            $response = Google_Http_REST::decodeHttpResponse($response);
+            $response = Google_Http_REST::decodeHttpResponse($response, $this->client);
             $responses[$key] = $response;
           } catch (Google_Service_Exception $e) {
             // Store the exception as the response, so successful responses

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -178,7 +178,7 @@ class Google_Http_MediaFileUpload
       // No problems, but upload not complete.
       return false;
     } else {
-      return Google_Http_REST::decodeHttpResponse($response);
+      return Google_Http_REST::decodeHttpResponse($response, $this->client);
     }
   }
 
@@ -292,6 +292,9 @@ class Google_Http_MediaFileUpload
       }
       $message = rtrim($message, ';');
     }
-    throw new Google_Exception("Failed to start the resumable upload (HTTP {$message})");
+
+    $error = "Failed to start the resumable upload (HTTP {$message})";
+    $this->client->getLogger()->error($error);
+    throw new Google_Exception($error);
   }
 }

--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -38,7 +38,7 @@ class Google_Http_REST
   {
     $httpRequest = $client->getIo()->makeRequest($req);
     $httpRequest->setExpectedClass($req->getExpectedClass());
-    return self::decodeHttpResponse($httpRequest);
+    return self::decodeHttpResponse($httpRequest, $client);
   }
 
   /**
@@ -46,9 +46,10 @@ class Google_Http_REST
    * @static
    * @throws Google_Service_Exception
    * @param Google_Http_Request $response The http response to be decoded.
+   * @param Google_Client $client
    * @return mixed|null
    */
-  public static function decodeHttpResponse($response)
+  public static function decodeHttpResponse($response, Google_Client $client = null)
   {
     $code = $response->getResponseHttpCode();
     $body = $response->getResponseBody();
@@ -73,6 +74,12 @@ class Google_Http_REST
         $errors = $decoded['error']['errors'];
       }
 
+      if ($client) {
+        $client->getLogger()->error(
+            $err,
+            array('code' => $code, 'errors' => $errors)
+        );
+      }
       throw new Google_Service_Exception($err, $code, null, $errors);
     }
 
@@ -80,7 +87,11 @@ class Google_Http_REST
     if ($code != '204') {
       $decoded = json_decode($body, true);
       if ($decoded === null || $decoded === "") {
-        throw new Google_Service_Exception("Invalid json in service response: $body");
+        $error = "Invalid json in service response: $body";
+        if ($client) {
+          $client->getLogger()->error($error);
+        }
+        throw new Google_Service_Exception($error);
       }
 
       if ($response->getExpectedClass()) {

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -53,9 +53,8 @@ class Google_IO_Curl extends Google_IO_Abstract
       }
       curl_setopt($curl, CURLOPT_HTTPHEADER, $curlHeaders);
     }
-
     curl_setopt($curl, CURLOPT_URL, $request->getUrl());
-    
+
     curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $request->getRequestMethod());
     curl_setopt($curl, CURLOPT_USERAGENT, $request->getUserAgent());
 
@@ -78,15 +77,36 @@ class Google_IO_Curl extends Google_IO_Abstract
       curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/cacerts.pem');
     }
 
+    $this->client->getLogger()->debug(
+        'cURL request',
+        array(
+            'url' => $request->getUrl(),
+            'method' => $request->getRequestMethod(),
+            'headers' => $requestHeaders,
+            'body' => $request->getPostBody()
+        )
+    );
+
     $response = curl_exec($curl);
     if ($response === false) {
-      throw new Google_IO_Exception(curl_error($curl));
+      $error = curl_error($curl);
+
+      $this->client->getLogger()->error('cURL ' . $error);
+      throw new Google_IO_Exception($error);
     }
     $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
 
     list($responseHeaders, $responseBody) = $this->parseHttpResponse($response, $headerSize);
-
     $responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+    $this->client->getLogger()->debug(
+        'cURL response',
+        array(
+            'code' => $responseCode,
+            'headers' => $responseHeaders,
+            'body' => $responseBody,
+        )
+    );
 
     return array($responseBody, $responseHeaders, $responseCode);
   }

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -97,6 +97,16 @@ class Google_IO_Stream extends Google_IO_Abstract
       $url = self::ZLIB . $url;
     }
 
+    $this->client->getLogger()->debug(
+        'Stream request',
+        array(
+            'url' => $url,
+            'method' => $request->getRequestMethod(),
+            'headers' => $requestHeaders,
+            'body' => $request->getPostBody()
+        )
+    );
+
     // We are trapping any thrown errors in this method only and
     // throwing an exception.
     $this->trappedErrorNumber = null;
@@ -109,13 +119,13 @@ class Google_IO_Stream extends Google_IO_Abstract
     // END - error trap.
 
     if ($this->trappedErrorNumber) {
-      throw new Google_IO_Exception(
-          sprintf(
-              "HTTP Error: Unable to connect: '%s'",
-              $this->trappedErrorString
-          ),
-          $this->trappedErrorNumber
+      $error = sprintf(
+          "HTTP Error: Unable to connect: '%s'",
+          $this->trappedErrorString
       );
+
+      $this->client->getLogger()->error('Stream ' . $error);
+      throw new Google_IO_Exception($error, $this->trappedErrorNumber);
     }
 
     $response_data = false;
@@ -132,16 +142,25 @@ class Google_IO_Stream extends Google_IO_Abstract
     }
 
     if (false === $response_data) {
-      throw new Google_IO_Exception(
-          sprintf(
-              "HTTP Error: Unable to connect: '%s'",
-              $respHttpCode
-          ),
+      $error = sprintf(
+          "HTTP Error: Unable to connect: '%s'",
           $respHttpCode
       );
+
+      $this->client->getLogger()->error('Stream ' . $error);
+      throw new Google_IO_Exception($error, $respHttpCode);
     }
 
     $responseHeaders = $this->getHttpResponseHeaders($http_response_header);
+
+    $this->client->getLogger()->debug(
+        'Stream response',
+        array(
+            'code' => $respHttpCode,
+            'headers' => $responseHeaders,
+            'body' => $response_data,
+        )
+    );
 
     return array($response_data, $responseHeaders, $respHttpCode);
   }

--- a/src/Google/Logger/Abstract.php
+++ b/src/Google/Logger/Abstract.php
@@ -1,0 +1,406 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Abstract logging class based on the PSR-3 standard.
+ *
+ * NOTE: We don't implement `Psr\Log\LoggerInterface` because we need to
+ * maintain PHP 5.2 support.
+ *
+ * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ */
+abstract class Google_Logger_Abstract
+{
+  /**
+   * Default log format
+   */
+  const DEFAULT_LOG_FORMAT = "[%datetime%] %level%: %message% %context%\n";
+  /**
+   * Default date format
+   *
+   * Example: 16/Nov/2014:03:26:16 -0500
+   */
+  const DEFAULT_DATE_FORMAT = 'd/M/Y:H:i:s O';
+
+  /**
+   * System is unusable
+   */
+  const EMERGENCY = 'emergency';
+  /**
+   * Action must be taken immediately
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   */
+  const ALERT = 'alert';
+  /**
+   * Critical conditions
+   *
+   * Example: Application component unavailable, unexpected exception.
+   */
+  const CRITICAL = 'critical';
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   */
+  const ERROR = 'error';
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   */
+  const WARNING = 'warning';
+  /**
+   * Normal but significant events.
+   */
+  const NOTICE = 'notice';
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   */
+  const INFO = 'info';
+  /**
+   * Detailed debug information.
+   */
+  const DEBUG = 'debug';
+
+  /**
+   * @var array $levels Logging levels
+   */
+  protected static $levels = array(
+      self::EMERGENCY  => 600,
+      self::ALERT => 550,
+      self::CRITICAL => 500,
+      self::ERROR => 400,
+      self::WARNING => 300,
+      self::NOTICE => 250,
+      self::INFO => 200,
+      self::DEBUG => 100,
+  );
+
+  /**
+   * @var integer $level The minimum logging level
+   */
+  protected $level = self::DEBUG;
+
+  /**
+   * @var string $logFormat The current log format
+   */
+  protected $logFormat = self::DEFAULT_LOG_FORMAT;
+  /**
+   * @var string $dateFormat The current date format
+   */
+  protected $dateFormat = self::DEFAULT_DATE_FORMAT;
+
+  /**
+   * @var boolean $allowNewLines If newlines are allowed
+   */
+  protected $allowNewLines = false;
+
+  /**
+   * @param Google_Client $client  The current Google client
+   */
+  public function __construct(Google_Client $client)
+  {
+    $this->setLevel(
+        $client->getClassConfig('Google_Logger_Abstract', 'level')
+    );
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'log_format');
+    $this->logFormat = $format ? $format : self::DEFAULT_LOG_FORMAT;
+
+    $format = $client->getClassConfig('Google_Logger_Abstract', 'date_format');
+    $this->dateFormat = $format ? $format : self::DEFAULT_DATE_FORMAT;
+
+    $this->allowNewLines = (bool) $client->getClassConfig(
+        'Google_Logger_Abstract',
+        'allow_newlines'
+    );
+  }
+
+  /**
+   * Sets the minimum logging level that this logger handles.
+   *
+   * @param integer $level
+   */
+  public function setLevel($level)
+  {
+    $this->level = $this->normalizeLevel($level);
+  }
+
+  /**
+   * Checks if the logger should handle messages at the provided level.
+   *
+   * @param  integer $level
+   * @return boolean
+   */
+  public function shouldHandle($level)
+  {
+    return $this->normalizeLevel($level) >= $this->level;
+  }
+
+  /**
+   * System is unusable.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function emergency($message, array $context = array())
+  {
+    $this->log(self::EMERGENCY, $message, $context);
+  }
+
+  /**
+   * Action must be taken immediately.
+   *
+   * Example: Entire website down, database unavailable, etc. This should
+   * trigger the SMS alerts and wake you up.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function alert($message, array $context = array())
+  {
+    $this->log(self::ALERT, $message, $context);
+  }
+
+  /**
+   * Critical conditions.
+   *
+   * Example: Application component unavailable, unexpected exception.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function critical($message, array $context = array())
+  {
+    $this->log(self::CRITICAL, $message, $context);
+  }
+
+  /**
+   * Runtime errors that do not require immediate action but should typically
+   * be logged and monitored.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function error($message, array $context = array())
+  {
+    $this->log(self::ERROR, $message, $context);
+  }
+
+  /**
+   * Exceptional occurrences that are not errors.
+   *
+   * Example: Use of deprecated APIs, poor use of an API, undesirable things
+   * that are not necessarily wrong.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function warning($message, array $context = array())
+  {
+    $this->log(self::WARNING, $message, $context);
+  }
+
+  /**
+   * Normal but significant events.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function notice($message, array $context = array())
+  {
+    $this->log(self::NOTICE, $message, $context);
+  }
+
+  /**
+   * Interesting events.
+   *
+   * Example: User logs in, SQL logs.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function info($message, array $context = array())
+  {
+    $this->log(self::INFO, $message, $context);
+  }
+
+  /**
+   * Detailed debug information.
+   *
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function debug($message, array $context = array())
+  {
+    $this->log(self::DEBUG, $message, $context);
+  }
+
+  /**
+   * Logs with an arbitrary level.
+   *
+   * @param mixed $level    The log level
+   * @param string $message The log message
+   * @param array $context  The log context
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $message = $this->interpolate(
+        array(
+            'message' => $message,
+            'context' => $context,
+            'level' => strtoupper($levelName),
+            'datetime' => new DateTime(),
+        )
+    );
+
+    $this->write($message);
+  }
+
+  /**
+   * Interpolates log variables into the defined log format.
+   *
+   * @param  array $variables The log variables.
+   * @return string
+   */
+  protected function interpolate(array $variables = array())
+  {
+    $template = $this->logFormat;
+
+    if (!$variables['context']) {
+      $template = str_replace('%context%', '', $template);
+      unset($variables['context']);
+    } else {
+      $this->reverseJsonInContext($variables['context']);
+    }
+
+    foreach ($variables as $key => $value) {
+      if (strpos($template, '%'. $key .'%') !== false) {
+        $template = str_replace(
+            '%' . $key . '%',
+            $this->export($value),
+            $template
+        );
+      }
+    }
+
+    return $template;
+  }
+
+  /**
+   * Reverses JSON encoded PHP arrays and objects so that they log better.
+   *
+   * @param array $context The log context
+   */
+  protected function reverseJsonInContext(array &$context)
+  {
+    if (!$context) {
+      return;
+    }
+
+    foreach ($context as $key => $val) {
+      if (!$val || !is_string($val) || !($val[0] == '{' || $val[0] == '[')) {
+        continue;
+      }
+
+      $json = @json_decode($val);
+      if (is_object($json) || is_array($json)) {
+        $context[$key] = $json;
+      }
+    }
+  }
+
+  /**
+   * Exports a PHP value for logging to a string.
+   *
+   * @param mixed $value The value to
+   */
+  protected function export($value)
+  {
+    if (is_string($value)) {
+      if ($this->allowNewLines) {
+        return $value;
+      }
+
+      return preg_replace('/[\r\n]+/', ' ', $value);
+    }
+
+    if (is_resource($value)) {
+      return sprintf(
+          'resource(%d) of type (%s)',
+          $value,
+          get_resource_type($value)
+      );
+    }
+
+    if ($value instanceof DateTime) {
+      return $value->format($this->dateFormat);
+    }
+
+    if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+      $options = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+      if ($this->allowNewLines) {
+        $options |= JSON_PRETTY_PRINT;
+      }
+
+      return @json_encode($value, $options);
+    }
+
+    return str_replace('\\/', '/', @json_encode($value));
+  }
+
+  /**
+   * Converts a given log level to the integer form.
+   *
+   * @param  mixed $level   The logging level
+   * @return integer $level The normalized level
+   * @throws Google_Logger_Exception If $level is invalid
+   */
+  protected function normalizeLevel($level)
+  {
+    if (is_int($level) && array_search($level, self::$levels) !== false) {
+      return $level;
+    }
+
+    if (is_string($level) && isset(self::$levels[$level])) {
+      return self::$levels[$level];
+    }
+
+    throw new Google_Logger_Exception(
+        sprintf("Unknown LogLevel: '%s'", $level)
+    );
+  }
+
+  /**
+   * Writes a message to the current log implementation.
+   *
+   * @param string $message The message
+   */
+  abstract protected function write($message);
+}

--- a/src/Google/Logger/Exception.php
+++ b/src/Google/Logger/Exception.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+class Google_Logger_Exception extends Google_Exception
+{
+}

--- a/src/Google/Logger/File.php
+++ b/src/Google/Logger/File.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * File logging class based on the PSR-3 standard.
+ *
+ * This logger writes to a PHP stream resource.
+ */
+class Google_Logger_File extends Google_Logger_Abstract
+{
+  /**
+   * @var string|resource $file Where logs are written
+   */
+  private $file;
+  /**
+   * @var integer $mode The mode to use if the log file needs to be created
+   */
+  private $mode = 0640;
+  /**
+   * @var boolean $lock If a lock should be attempted before writing to the log
+   */
+  private $lock = false;
+
+  /**
+   * @var integer $trappedErrorNumber Trapped error number
+   */
+  private $trappedErrorNumber;
+  /**
+   * @var string $trappedErrorString Trapped error string
+   */
+  private $trappedErrorString;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(Google_Client $client)
+  {
+    parent::__construct($client);
+
+    $file = $client->getClassConfig('Google_Logger_File', 'file');
+    if (!is_string($file) && !is_resource($file)) {
+      throw new Google_Logger_Exception(
+          'File logger requires a filename or a valid file pointer'
+      );
+    }
+
+    $mode = $client->getClassConfig('Google_Logger_File', 'mode');
+    if (!$mode) {
+      $this->mode = $mode;
+    }
+
+    $this->lock = (bool) $client->getClassConfig('Google_Logger_File', 'lock');
+    $this->file = $file;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message)
+  {
+    if (is_string($this->file)) {
+      $this->open();
+    } elseif (!is_resource($this->file)) {
+      throw new Google_Logger_Exception('File pointer is no longer available');
+    }
+
+    if ($this->lock) {
+      flock($this->file, LOCK_EX);
+    }
+
+    fwrite($this->file, (string) $message);
+
+    if ($this->lock) {
+      flock($this->file, LOCK_UN);
+    }
+  }
+
+  /**
+   * Opens the log for writing.
+   *
+   * @return resource
+   */
+  private function open()
+  {
+    // Used for trapping `fopen()` errors.
+    $this->trappedErrorNumber = null;
+    $this->trappedErrorString = null;
+
+    $old = set_error_handler(array($this, 'trapError'));
+
+    $needsChmod = !file_exists($this->file);
+    $fh = fopen($this->file, 'a');
+
+    restore_error_handler();
+
+    // Handles trapped `fopen()` errors.
+    if ($this->trappedErrorNumber) {
+      throw new Google_Logger_Exception(
+          sprintf(
+              "Logger Error: '%s'",
+              $this->trappedErrorString
+          ),
+          $this->trappedErrorNumber
+      );
+    }
+
+    if ($needsChmod) {
+      @chmod($this->file, $this->mode & ~umask());
+    }
+
+    return $this->file = $fh;
+  }
+
+  /**
+   * Closes the log stream resource.
+   */
+  private function close()
+  {
+    if (is_resource($this->file)) {
+      fclose($this->file);
+    }
+  }
+
+  /**
+   * Traps `fopen()` errors.
+   *
+   * @param integer $errno The error number
+   * @param string $errstr The error string
+   */
+  private function trapError($errno, $errstr)
+  {
+    $this->trappedErrorNumber = $errno;
+    $this->trappedErrorString = $errstr;
+  }
+
+  public function __destruct()
+  {
+    $this->close();
+  }
+}

--- a/src/Google/Logger/Null.php
+++ b/src/Google/Logger/Null.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Null logger based on the PSR-3 standard.
+ *
+ * This logger simply discards all messages.
+ */
+class Google_Logger_Null extends Google_Logger_Abstract
+{
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return false;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
+}

--- a/src/Google/Logger/Psr.php
+++ b/src/Google/Logger/Psr.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Psr logging class based on the PSR-3 standard.
+ *
+ * This logger will delegate all logging to a PSR-3 compatible logger specified
+ * with the `Google_Logger_Psr::setLogger()` method.
+ */
+class Google_Logger_Psr extends Google_Logger_Abstract
+{
+  /**
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  private $logger;
+
+  /**
+   * @param Google_Client $client           The current Google client
+   * @param Psr\Log\LoggerInterface $logger PSR-3 logger where logging will be delegated.
+   */
+  public function __construct(Google_Client $client, /*Psr\Log\LoggerInterface*/ $logger = null)
+  {
+    parent::__construct($client);
+
+    if ($logger) {
+      $this->setLogger($logger);
+    }
+  }
+
+  /**
+   * Sets the PSR-3 logger where logging will be delegated.
+   *
+   * NOTE: The `$logger` should technically implement
+   * `Psr\Log\LoggerInterface`, but we don't explicitly require this so that
+   * we can be compatible with PHP 5.2.
+   *
+   * @param Psr\Log\LoggerInterface $logger The PSR-3 logger
+   */
+  public function setLogger(/*Psr\Log\LoggerInterface*/ $logger)
+  {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function shouldHandle($level)
+  {
+    return isset($this->logger) && parent::shouldHandle($level);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = array())
+  {
+    if (!$this->shouldHandle($level)) {
+      return false;
+    }
+
+    if ($context) {
+      $this->reverseJsonInContext($context);
+    }
+
+    $levelName = is_int($level) ? array_search($level, self::$levels) : $level;
+    $this->logger->log($levelName, $message, $context);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function write($message, array $context = array())
+  {
+  }
+}

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -79,6 +79,15 @@ class Google_Service_Resource
   public function call($name, $arguments, $expected_class = null)
   {
     if (! isset($this->methods[$name])) {
+      $this->client->getLogger()->error(
+          'Service method unknown',
+          array(
+              'service' => $this->serviceName,
+              'resource' => $this->resourceName,
+              'method' => $name
+          )
+      );
+
       throw new Google_Exception(
           "Unknown function: " .
           "{$this->serviceName}->{$this->resourceName}->{$name}()"
@@ -124,6 +133,15 @@ class Google_Service_Resource
     );
     foreach ($parameters as $key => $val) {
       if ($key != 'postBody' && ! isset($method['parameters'][$key])) {
+        $this->client->getLogger()->error(
+            'Service parameter unknown',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $key
+            )
+        );
         throw new Google_Exception("($name) unknown parameter: '$key'");
       }
     }
@@ -133,6 +151,15 @@ class Google_Service_Resource
           $paramSpec['required'] &&
           ! isset($parameters[$paramName])
       ) {
+        $this->client->getLogger()->error(
+            'Service parameter missing',
+            array(
+                'service' => $this->serviceName,
+                'resource' => $this->resourceName,
+                'method' => $name,
+                'parameter' => $paramName
+            )
+        );
         throw new Google_Exception("($name) missing required param: '$paramName'");
       }
       if (isset($parameters[$paramName])) {
@@ -147,6 +174,16 @@ class Google_Service_Resource
     }
 
     $servicePath = $this->service->servicePath;
+
+    $this->client->getLogger()->info(
+        'Service Call',
+        array(
+            'service' => $this->serviceName,
+            'resource' => $this->resourceName,
+            'method' => $name,
+            'arguments' => $parameters,
+        )
+    );
 
     $url = Google_Http_REST::createRequestUri(
         $servicePath,

--- a/tests/general/LoggerTest.php
+++ b/tests/general/LoggerTest.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class LoggerTest extends PHPUnit_Framework_TestCase
+{
+  private $client;
+
+  public function setup()
+  {
+    $this->client = new Google_Client();
+  }
+
+  /**
+   * @dataProvider logLevelsProvider
+   */
+  public function testPsrMethods($key)
+  {
+    $message = 'This is my log message';
+    $context = array('some'=>'context');
+
+    $logger = $this->getLogger('log');
+    $logger->expects($this->once())
+           ->method('log')
+           ->with($key, $message, $context);
+
+    call_user_func(array($logger, $key), $message, $context);
+  }
+
+  /**
+   * @dataProvider invalidLevelsProvider
+   * @expectedException Google_Logger_Exception
+   * @expectedExceptionMessage Unknown LogLevel
+   */
+  public function testSetLabelWithBadValue($level)
+  {
+    $this->getLogger()->setLevel($level);
+  }
+
+  /**
+   * @dataProvider invalidLevelsProvider
+   * @expectedException Google_Logger_Exception
+   * @expectedExceptionMessage Unknown LogLevel
+   */
+  public function testSetLabelWithBadValueFromConfig($level)
+  {
+    $this->client->setClassConfig('Google_Logger_Abstract', 'level', $level);
+    $this->getLogger();
+  }
+
+  /**
+   * @dataProvider filterProvider
+   */
+  public function testShouldHandle($setLevel, $handleLevel, $expected)
+  {
+    $logger = $this->getLogger();
+    $logger->setLevel($setLevel);
+
+    $this->assertEquals($expected, $logger->shouldHandle($handleLevel));
+  }
+
+  /**
+   * @dataProvider filterProvider
+   */
+  public function testShouldHandleFromConfig($config, $handleLevel, $expected)
+  {
+    $this->client->setClassConfig('Google_Logger_Abstract', 'level', $config);
+    $logger = $this->getLogger();
+
+    $this->assertEquals($expected, $logger->shouldHandle($handleLevel));
+  }
+
+  /**
+   * @dataProvider filterProvider
+   */
+  public function testShouldWrite($setLevel, $logLevel, $expected)
+  {
+    $logger = $this->getLogger();
+    $logger->expects($expected ? $this->once() : $this->never())
+           ->method('write');
+
+    $logger->setLevel($setLevel);
+    $logger->log($logLevel, 'This is my log message');
+  }
+
+  /**
+   * @dataProvider filterProvider
+   */
+  public function testShouldWriteFromConfig($config, $logLevel, $expected)
+  {
+    $this->client->setClassConfig('Google_Logger_Abstract', 'level', $config);
+    $logger = $this->getLogger();
+    $logger->expects($expected ? $this->once() : $this->never())
+           ->method('write');
+
+    $logger->log($logLevel, 'This is my log message');
+  }
+
+  /**
+   * @dataProvider formattingProvider
+   */
+  public function testMessageFormatting(
+      $format,
+      $date_format,
+      $newlines,
+      $message,
+      $context,
+      $expected
+  ) {
+    $this->client->setClassConfig(
+        'Google_Logger_Abstract',
+        'log_format',
+        $format
+    );
+    $this->client->setClassConfig(
+        'Google_Logger_Abstract',
+        'date_format',
+        $date_format
+    );
+    $this->client->setClassConfig(
+        'Google_Logger_Abstract',
+        'allow_newlines',
+        $newlines
+    );
+
+    $logger = $this->getLogger();
+    $logger->expects($this->once())
+           ->method('write')
+           ->with($expected);
+
+    $logger->log('debug', $message, $context);
+  }
+
+  public function testNullLoggerNeverWrites()
+  {
+    $logger = $this->getLogger('write', 'Google_Logger_Null');
+    $logger->expects($this->never())
+           ->method('write');
+
+    $logger->log(
+        'emergency',
+        'Should not be written',
+        array('same' => 'for this')
+    );
+  }
+
+  public function testNullLoggerNeverHandles()
+  {
+    $logger = $this->getLogger('write', 'Google_Logger_Null');
+    $this->assertFalse($logger->shouldHandle('emergency'));
+    $this->assertFalse($logger->shouldHandle(600));
+  }
+
+  public function testPsrNeverWrites()
+  {
+    $logger = $this->getLogger('write', 'Google_Logger_Psr');
+    $logger->expects($this->never())
+           ->method('write');
+
+    $logger->log(
+        'emergency',
+        'Should not be written',
+        array('same' => 'for this')
+    );
+
+    $logger->setLogger($this->getLogger());
+
+    $logger->log(
+        'emergency',
+        'Should not be written',
+        array('same' => 'for this')
+    );
+  }
+
+  public function testPsrNeverShouldHandleWhenNoLoggerSet()
+  {
+    $logger = $this->getLogger(null, 'Google_Logger_Psr');
+    $this->assertFalse($logger->shouldHandle('emergency'));
+    $this->assertFalse($logger->shouldHandle(600));
+  }
+
+  public function testPsrShouldHandleWhenLoggerSet()
+  {
+    $logger = $this->getLogger(null, 'Google_Logger_Psr');
+    $logger->setLogger($this->getLogger());
+
+    $this->assertTrue($logger->shouldHandle('emergency'));
+    $this->assertTrue($logger->shouldHandle(600));
+  }
+
+  /**
+   * @dataProvider logLevelsProvider
+   */
+  public function testPsrDelegates($key)
+  {
+    $message = 'This is my log message';
+    $context = array('some'=>'context');
+
+    $delegate = $this->getLogger('log');
+    $delegate->expects($this->once())
+             ->method('log')
+             ->with($key, $message, $context);
+
+    $logger = $this->getLogger(null, 'Google_Logger_Psr');
+    $logger->setLogger($delegate);
+
+    call_user_func(array($logger, $key), $message, $context);
+  }
+
+  /**
+   * @expectedException Google_Logger_Exception
+   * @expectedExceptionMessage File logger requires a filename or a valid file pointer
+   */
+  public function testLoggerWithBadFileType()
+  {
+    $this->client->setClassConfig('Google_Logger_File', 'file', false);
+    $logger = $this->getLogger(null, 'Google_Logger_File');
+  }
+
+  /**
+   * @expectedException Google_Logger_Exception
+   * @expectedExceptionMessage Logger Error
+   */
+  public function testLoggerWithBadFileValue()
+  {
+    $this->client->setClassConfig('Google_Logger_File', 'file', 'not://exist');
+
+    $logger = $this->getLogger(null, 'Google_Logger_File');
+    $logger->log('emergency', 'will fail');
+  }
+
+  /**
+   * @expectedException Google_Logger_Exception
+   * @expectedExceptionMessage File pointer is no longer available
+   */
+  public function testLoggerWithClosedFileReference()
+  {
+    $fp = fopen('php://memory', 'r+');
+
+    $this->client->setClassConfig('Google_Logger_File', 'file', $fp);
+    $logger = $this->getLogger(null, 'Google_Logger_File');
+
+    fclose($fp);
+
+    $logger->log('emergency', 'will fail');
+  }
+
+  public function testLoggerWithFileReference()
+  {
+    $fp = fopen('php://memory', 'r+');
+
+    $this->client->setClassConfig('Google_Logger_File', 'file', $fp);
+    $this->client->setClassConfig(
+        'Google_Logger_Abstract',
+        'log_format',
+        "%level% - %message%\n"
+    );
+
+    $logger = $this->getLogger(null, 'Google_Logger_File');
+    $logger->log('emergency', 'test one');
+    $logger->log('alert', 'test two');
+    $logger->log(500, 'test three');
+
+    rewind($fp);
+    $this->assertEquals(
+        "EMERGENCY - test one\nALERT - test two\nCRITICAL - test three\n",
+        stream_get_contents($fp)
+    );
+
+    fclose($fp);
+  }
+
+  public function testLoggerWithFile()
+  {
+    $this->expectOutputString(
+        "EMERGENCY - test one\nALERT - test two\nCRITICAL - test three\n"
+    );
+
+    $this->client->setClassConfig(
+        'Google_Logger_File',
+        'file',
+        'php://output'
+    );
+    $this->client->setClassConfig(
+        'Google_Logger_Abstract',
+        'log_format',
+        "%level% - %message%\n"
+    );
+
+    $logger = $this->getLogger(null, 'Google_Logger_File');
+    $logger->log('emergency', 'test one');
+    $logger->log('alert', 'test two');
+    $logger->log(500, 'test three');
+  }
+
+  public function formattingProvider()
+  {
+    return array(
+        'no interpolation' => array(
+            'this is my format',
+            'd/M/Y:H:i:s O',
+            false,
+            'you wont see this',
+            array('or' => 'this'),
+            'this is my format',
+        ),
+        'only message interpolation' => array(
+            'my format: %message%',
+            'd/M/Y:H:i:s O',
+            false,
+            'you will see this',
+            array('but not' => 'this'),
+            'my format: you will see this',
+        ),
+        'message and level interpolation' => array(
+            '%level% - my format: %message%',
+            'd/M/Y:H:i:s O',
+            false,
+            'you will see this',
+            array('but not' => 'this'),
+            'DEBUG - my format: you will see this',
+        ),
+        'message, level, datetime interpolation' => array(
+            '[%datetime%] %level% - my format: %message%',
+            '\T\I\M\E',
+            false,
+            'you will see this',
+            array('but not' => 'this'),
+            '[TIME] DEBUG - my format: you will see this',
+        ),
+        'message, level, datetime, context interpolation' => array(
+            '[%datetime%] %level% - my format: %message%: %context%',
+            '\T\I\M\E',
+            false,
+            'you will see this',
+            array('and' => 'this'),
+            '[TIME] DEBUG - my format: you will see this: {"and":"this"}',
+        ),
+        'reverse JSON in context' => array(
+            '%context%',
+            'd/M/Y:H:i:s O',
+            false,
+            'you will not see this',
+            array('reverse' => json_encode(array('this' => 'is cool'))),
+            '{"reverse":{"this":"is cool"}}',
+        ),
+        'remove newlines in message' => array(
+            '%message%',
+            'd/M/Y:H:i:s O',
+            false,
+            "This \n\n\r\n is \r my \r\n newlines \r\r\r\n\n message",
+            array('you wont' => 'see this'),
+            'This   is   my   newlines   message',
+        ),
+        'allow newlines in message' => array(
+            '%message%',
+            'd/M/Y:H:i:s O',
+            true,
+            "This \n\n\r\n is \r my \r\n newlines \r\r\r\n\n message",
+            array('you wont' => 'see this'),
+            "This \n\n\r\n is \r my \r\n newlines \r\r\r\n\n message",
+        ),
+        'allow newlines in JSON' => array(
+            '%context%',
+            'd/M/Y:H:i:s O',
+            true,
+            "wont see this",
+            array('you will' => 'see this'),
+            version_compare(PHP_VERSION, '5.4.0', '>=') ?
+            "{\n    \"you will\": \"see this\"\n}" :
+            '{"you will":"see this"}'
+        ),
+    );
+  }
+
+  public function filterProvider()
+  {
+    return array(
+        array('debug', 'debug', true),
+        array(100, 'debug', true),
+        array('info', 'debug', false),
+        array('info', 'notice', true),
+        array('notice', 'notice', true),
+        array(250, 'notice', true),
+        array('notice', 'debug', false),
+        array(250, 'alert', true),
+        array('error', 'error', true),
+        array('error', 'warning', false),
+        array('error', 'critical', true),
+        array(600, 'alert', false),
+        array(600, 'critical', false),
+        array(600, 'emergency', true),
+        array('emergency', 'emergency', true),
+    );
+  }
+
+  public function invalidLevelsProvider()
+  {
+    return array(
+        array('100'),
+        array('DEBUG'),
+        array(100.0),
+        array(''),
+        array(0),
+    );
+  }
+
+  public function logLevelsProvider()
+  {
+    return array(
+        array('emergency', 600),
+        array('alert', 550),
+        array('critical', 500),
+        array('error', 400),
+        array('warning', 300),
+        array('notice', 250),
+        array('info', 200),
+        array('debug', 100),
+    );
+  }
+
+  private function getLogger($methods = null, $type = 'Google_Logger_Abstract')
+  {
+    return $this->getMockBuilder($type)
+                ->setMethods((array) $methods)
+                ->setConstructorArgs(array($this->client))
+                ->getMockForAbstractClass();
+  }
+}

--- a/tests/general/RestTest.php
+++ b/tests/general/RestTest.php
@@ -33,7 +33,7 @@ class RestTest extends BaseTest
     $client = $this->getClient();
     $response = new Google_Http_Request($url);
     $response->setResponseHttpCode(204);
-    $decoded = $this->rest->decodeHttpResponse($response);
+    $decoded = $this->rest->decodeHttpResponse($response, $client);
     $this->assertEquals(null, $decoded);
 
 
@@ -43,7 +43,7 @@ class RestTest extends BaseTest
       $response->setResponseBody('{"a": 1}');
 
       $response->setResponseHttpCode($code);
-      $decoded = $this->rest->decodeHttpResponse($response);
+      $decoded = $this->rest->decodeHttpResponse($response, $client);
       $this->assertEquals(array("a" => 1), $decoded);
     }
 
@@ -52,7 +52,7 @@ class RestTest extends BaseTest
 
     $error = "";
     try {
-      $this->rest->decodeHttpResponse($response);
+      $this->rest->decodeHttpResponse($response, $client);
     } catch (Exception $e) {
       $error = $e->getMessage();
 


### PR DESCRIPTION
More information on PSR-3 here: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md

This logging system roughly complies with the requirements for PSR-3, but does
not actually extend/implement/reuse any of the PSR namespaces, classes or
interfaces. This decision was made in an effort to maintain compatibility with
PHP 5.2+ and to be consistent with the current style of this library.

Four new logging classes are available out of the box:
1. Google_Logger_Abstract: This abstract class implements most of the
   functionality required for a logger. The only detail that is left to the
   concrete classes is the `write()` method. If you want to create a custom
   logger, you should extend this class.
2. Google_Logger_Null: This logger simply discards all messages. You can use
   this logger to ensure that no messages will be logged. This is the default
   logger.
3. Google_Logger_File: This logger will write messages to just about any
   writable stream resource you give it.
4. Google_Logger_Psr: This logger exists to allow for interoperability with
   other PSR-3 logging systems. All you need to do is provide this logger
   with and instance of another logger and you're done. Below is an
   example of integrating with Monolog:

``` php
use Monolog\Logger;
use Monolog\Handler\StreamHandler;

$monolog = new Logger('Google API');
$monolog->pushHandler(new StreamHandler('php://output', Logger::INFO));

$config = new Google_Config();
$config->setLoggerClass('Google_Logger_Psr');

$client = new Google_Client($config);
$client->getLogger()->setLogger($monolog);

// Logs: [2014-11-16 16:28:21] Google API.INFO: Service Call {"service":"books"...
$service = new Google_Service_Books($client);
$service->volumes->listVolumes('Henry David Thoreau');

// Logs: [2014-11-16 16:28:21] Google API.ERROR: My custom error
$client->getLogger()->error('My custom error');
```
