### PR TITLE
Changing visibility of private attributes to protected

### DIFF
--- a/src/Google/Auth/AppIdentity.php
+++ b/src/Google/Auth/AppIdentity.php
@@ -30,10 +30,10 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 class Google_Auth_AppIdentity extends Google_Auth_Abstract
 {
   const CACHE_PREFIX = "Google_Auth_AppIdentity::";
-  private $key = null;
-  private $client;
-  private $token = false;
-  private $tokenScopes = false;
+  protected $key = null;
+  protected $client;
+  protected $token = false;
+  protected $tokenScopes = false;
 
   public function __construct(Google_Client $client, $config = null)
   {

--- a/src/Google/Auth/AssertionCredentials.php
+++ b/src/Google/Auth/AssertionCredentials.php
@@ -37,7 +37,7 @@ class Google_Auth_AssertionCredentials
    * @link http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06
    */
   public $prn;
-  private $useCache;
+  protected $useCache;
 
   /**
    * @param $serviceAccountName

--- a/src/Google/Auth/LoginTicket.php
+++ b/src/Google/Auth/LoginTicket.php
@@ -27,10 +27,10 @@ class Google_Auth_LoginTicket
   const USER_ATTR = "sub";
 
   // Information from id token envelope.
-  private $envelope;
+  protected $envelope;
 
   // Information from id token payload.
-  private $payload;
+  protected $payload;
 
   /**
    * Creates a user based on the supplied token.

--- a/src/Google/Auth/OAuth2.php
+++ b/src/Google/Auth/OAuth2.php
@@ -35,22 +35,22 @@ class Google_Auth_OAuth2 extends Google_Auth_Abstract
   const OAUTH2_ISSUER = 'accounts.google.com';
 
   /** @var Google_Auth_AssertionCredentials $assertionCredentials */
-  private $assertionCredentials;
+  protected $assertionCredentials;
 
   /**
    * @var string The state parameters for CSRF and other forgery protection.
    */
-  private $state;
+  protected $state;
 
   /**
    * @var array The token bundle.
    */
-  private $token = array();
+  protected $token = array();
 
   /**
    * @var Google_Client the base client
    */
-  private $client;
+  protected $client;
 
   /**
    * Instantiates the class, but does not initiate the login flow, leaving it

--- a/src/Google/Auth/Simple.php
+++ b/src/Google/Auth/Simple.php
@@ -26,8 +26,8 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
  */
 class Google_Auth_Simple extends Google_Auth_Abstract
 {
-  private $key = null;
-  private $client;
+  protected $key = null;
+  protected $client;
 
   public function __construct(Google_Client $client, $config = null)
   {

--- a/src/Google/Cache/File.php
+++ b/src/Google/Cache/File.php
@@ -28,8 +28,8 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 class Google_Cache_File extends Google_Cache_Abstract
 {
   const MAX_LOCK_RETRIES = 10;
-  private $path;
-  private $fh;
+  protected $path;
+  protected $fh;
 
   public function __construct(Google_Client $client)
   {

--- a/src/Google/Cache/Memcache.php
+++ b/src/Google/Cache/Memcache.php
@@ -29,10 +29,10 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
  */
 class Google_Cache_Memcache extends Google_Cache_Abstract
 {
-  private $connection = false;
-  private $mc = false;
-  private $host;
-  private $port;
+  protected $connection = false;
+  protected $mc = false;
+  protected $host;
+  protected $port;
 
   public function __construct(Google_Client $client)
   {

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -31,27 +31,27 @@ class Google_Client
   /**
    * @var Google_Auth_Abstract $auth
    */
-  private $auth;
+  protected $auth;
 
   /**
    * @var Google_IO_Abstract $io
    */
-  private $io;
+  protected $io;
 
   /**
    * @var Google_Cache_Abstract $cache
    */
-  private $cache;
+  protected $cache;
 
   /**
    * @var Google_Config $config
    */
-  private $config;
+  protected $config;
 
   /**
    * @var boolean $deferExecution
    */
-  private $deferExecution = false;
+  protected $deferExecution = false;
 
   /** @var array $scopes */
   // Scopes requested by the client
@@ -61,7 +61,7 @@ class Google_Client
   protected $services = array();
 
   // Used to track authenticated state, can't discover services after doing authenticate()
-  private $authenticated = false;
+  protected $authenticated = false;
 
   /**
    * Construct the Google Client.

--- a/src/Google/Http/Batch.php
+++ b/src/Google/Http/Batch.php
@@ -23,17 +23,17 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 class Google_Http_Batch
 {
   /** @var string Multipart Boundary. */
-  private $boundary;
+  protected $boundary;
 
   /** @var array service requests to be executed. */
-  private $requests = array();
+  protected $requests = array();
 
   /** @var Google_Client */
-  private $client;
+  protected $client;
 
-  private $expected_classes = array();
+  protected $expected_classes = array();
 
-  private $base_path;
+  protected $base_path;
 
   public function __construct(Google_Client $client, $boundary = false)
   {

--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -28,40 +28,40 @@ class Google_Http_MediaFileUpload
   const UPLOAD_RESUMABLE_TYPE = 'resumable';
 
   /** @var string $mimeType */
-  private $mimeType;
+  protected $mimeType;
 
   /** @var string $data */
-  private $data;
+  protected $data;
 
   /** @var bool $resumable */
-  private $resumable;
+  protected $resumable;
 
   /** @var int $chunkSize */
-  private $chunkSize;
+  protected $chunkSize;
 
   /** @var int $size */
-  private $size;
+  protected $size;
 
   /** @var string $resumeUri */
-  private $resumeUri;
+  protected $resumeUri;
 
   /** @var int $progress */
-  private $progress;
+  protected $progress;
 
   /** @var Google_Client */
-  private $client;
+  protected $client;
 
   /** @var Google_Http_Request */
-  private $request;
+  protected $request;
 
   /** @var string */
-  private $boundary;
+  protected $boundary;
 
   /**
    * Result code from last HTTP call
    * @var int
    */
-  private $httpResultCode;
+  protected $httpResultCode;
 
   /**
    * @param $mimeType string

--- a/src/Google/Http/Request.php
+++ b/src/Google/Http/Request.php
@@ -29,7 +29,7 @@ class Google_Http_Request
 {
   const GZIP_UA = " (gzip)";
 
-  private $batchHeaders = array(
+  protected $batchHeaders = array(
     'Content-Type' => 'application/http',
     'Content-Transfer-Encoding' => 'binary',
     'MIME-Version' => '1.0',

--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -28,7 +28,7 @@ class Google_IO_Curl extends Google_IO_Abstract
   // cURL hex representation of version 7.30.0
   const NO_QUIRK_VERSION = 0x071E00;
 
-  private $options = array();
+  protected $options = array();
   /**
    * Execute an HTTP Request
    *

--- a/src/Google/IO/Stream.php
+++ b/src/Google/IO/Stream.php
@@ -27,9 +27,9 @@ class Google_IO_Stream extends Google_IO_Abstract
 {
   const TIMEOUT = "timeout";
   const ZLIB = "compress.zlib://";
-  private $options = array();
-  private $trappedErrorNumber;
-  private $trappedErrorString;
+  protected $options = array();
+  protected $trappedErrorNumber;
+  protected $trappedErrorString;
 
   private static $DEFAULT_HTTP_CONTEXT = array(
     "follow_location" => 0,

--- a/src/Google/Service.php
+++ b/src/Google/Service.php
@@ -21,7 +21,7 @@ class Google_Service
   public $servicePath;
   public $availableScopes;
   public $resource;
-  private $client;
+  protected $client;
 
   public function __construct(Google_Client $client)
   {

--- a/src/Google/Service/Freebase.php
+++ b/src/Google/Service/Freebase.php
@@ -33,7 +33,7 @@ class Google_Service_Freebase extends Google_Service
 
 
 
-  private $base_methods;
+  protected $base_methods;
 
   /**
    * Constructs the internal representation of the Freebase service.

--- a/src/Google/Service/Oauth2.php
+++ b/src/Google/Service/Oauth2.php
@@ -45,7 +45,7 @@ class Google_Service_Oauth2 extends Google_Service
 
   public $userinfo;
   public $userinfo_v2_me;
-  private $base_methods;
+  protected $base_methods;
 
   /**
    * Constructs the internal representation of the Oauth2 service.

--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -29,7 +29,7 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 class Google_Service_Resource
 {
   // Valid query parameters that work, but don't appear in discovery.
-  private $stackParameters = array(
+  protected $stackParameters = array(
       'alt' => array('type' => 'string', 'location' => 'query'),
       'fields' => array('type' => 'string', 'location' => 'query'),
       'trace' => array('type' => 'string', 'location' => 'query'),
@@ -43,19 +43,19 @@ class Google_Service_Resource
   );
 
   /** @var Google_Service $service */
-  private $service;
+  protected $service;
 
   /** @var Google_Client $client */
-  private $client;
+  protected $client;
 
   /** @var string $serviceName */
-  private $serviceName;
+  protected $serviceName;
 
   /** @var string $resourceName */
-  private $resourceName;
+  protected $resourceName;
 
   /** @var array $methods */
-  private $methods;
+  protected $methods;
 
   public function __construct($service, $serviceName, $resourceName, $resource)
   {

--- a/src/Google/Signer/P12.php
+++ b/src/Google/Signer/P12.php
@@ -27,7 +27,7 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 class Google_Signer_P12 extends Google_Signer_Abstract
 {
   // OpenSSL private key resource
-  private $privateKey;
+  protected $privateKey;
 
   // Creates a new signer from a .p12 file.
   public function __construct($p12, $password)

--- a/src/Google/Utils/URITemplate.php
+++ b/src/Google/Utils/URITemplate.php
@@ -31,7 +31,7 @@ class Google_Utils_URITemplate
    * modify the way in which the variables inside are
    * processed.
    */
-  private $operators = array(
+  protected $operators = array(
       "+" => "reserved",
       "/" => "segments",
       "." => "dotprefix",
@@ -46,11 +46,11 @@ class Google_Utils_URITemplate
    * These are the characters which should not be URL encoded in reserved
    * strings.
    */
-  private $reserved = array(
+  protected $reserved = array(
       "=", ",", "!", "@", "|", ":", "/", "?", "#",
       "[", "]",'$', "&", "'", "(", ")", "*", "+", ";"
   );
-  private $reservedEncoded = array(
+  protected $reservedEncoded = array(
     "%3D", "%2C", "%21", "%40", "%7C", "%3A", "%2F", "%3F",
     "%23", "%5B", "%5D", "%24", "%26", "%27", "%28", "%29",
     "%2A", "%2B", "%3B"

--- a/src/Google/Verifier/Pem.php
+++ b/src/Google/Verifier/Pem.php
@@ -24,7 +24,7 @@ require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
  */
 class Google_Verifier_Pem extends Google_Verifier_Abstract
 {
-  private $publicKey;
+  protected $publicKey;
 
   /**
    * Constructs a verifier from the supplied PEM-encoded certificate.


### PR DESCRIPTION
It's currently impossible to cleanly override classes in this library, due to the private visibility of most attributes. With this change, overriding would be much easier. 
