### PR TITLE
Add support for retrying failed requests with exponential backoff.

### DIFF
--- a/src/Google/IO/Curl.php
+++ b/src/Google/IO/Curl.php
@@ -90,9 +90,11 @@ class Google_IO_Curl extends Google_IO_Abstract
     $response = curl_exec($curl);
     if ($response === false) {
       $error = curl_error($curl);
+      $code = curl_errno($curl);
+      $map = $this->client->getClassConfig('Google_IO_Exception', 'retry_map');
 
       $this->client->getLogger()->error('cURL ' . $error);
-      throw new Google_IO_Exception($error);
+      throw new Google_IO_Exception($error, $code, null, $map);
     }
     $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
 

--- a/src/Google/IO/Exception.php
+++ b/src/Google/IO/Exception.php
@@ -17,6 +17,51 @@
 
 require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_IO_Exception extends Google_Exception
+class Google_IO_Exception extends Google_Exception implements Google_Task_Retryable
 {
+  /**
+   * @var array $retryMap Map of errors with retry counts.
+   */
+  private $retryMap = array();
+
+  /**
+   * Creates a new IO exception with an optional retry map.
+   *
+   * @param string $message
+   * @param int $code
+   * @param Exception|null $previous
+   * @param array|null $retryMap Map of errors with retry counts.
+   */
+  public function __construct(
+      $message,
+      $code = 0,
+      Exception $previous = null,
+      array $retryMap = null
+  ) {
+    if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
+      parent::__construct($message, $code, $previous);
+    } else {
+      parent::__construct($message, $code);
+    }
+
+    if (is_array($retryMap)) {
+      $this->retryMap = $retryMap;
+    }
+  }
+
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries()
+  {
+    if (isset($this->retryMap[$this->code])) {
+      return $this->retryMap[$this->code];
+    }
+
+    return 0;
+  }
 }

--- a/src/Google/Service/Exception.php
+++ b/src/Google/Service/Exception.php
@@ -1,8 +1,23 @@
 <?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
 
-class Google_Service_Exception extends Google_Exception
+class Google_Service_Exception extends Google_Exception implements Google_Task_Retryable
 {
   /**
    * Optional list of errors returned in a JSON body of an HTTP error response.
@@ -10,19 +25,27 @@ class Google_Service_Exception extends Google_Exception
   protected $errors = array();
 
   /**
-   * Override default constructor to add ability to set $errors.
+   * @var array $retryMap Map of errors with retry counts.
+   */
+  private $retryMap = array();
+
+  /**
+   * Override default constructor to add the ability to set $errors and a retry
+   * map.
    *
    * @param string $message
    * @param int $code
    * @param Exception|null $previous
    * @param [{string, string}] errors List of errors returned in an HTTP
    * response.  Defaults to [].
+   * @param array|null $retryMap Map of errors with retry counts.
    */
   public function __construct(
       $message,
       $code = 0,
       Exception $previous = null,
-      $errors = array()
+      $errors = array(),
+      array $retryMap = null
   ) {
     if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
       parent::__construct($message, $code, $previous);
@@ -31,6 +54,10 @@ class Google_Service_Exception extends Google_Exception
     }
 
     $this->errors = $errors;
+
+    if (is_array($retryMap)) {
+      $this->retryMap = $retryMap;
+    }
   }
 
   /**
@@ -49,5 +76,28 @@ class Google_Service_Exception extends Google_Exception
   public function getErrors()
   {
     return $this->errors;
+  }
+
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries()
+  {
+    if (isset($this->retryMap[$this->code])) {
+      return $this->retryMap[$this->code];
+    }
+
+    $errors = $this->getErrors();
+
+    if (!empty($errors) && isset($errors[0]['reason']) &&
+        isset($this->retryMap[$errors[0]['reason']])) {
+      return $this->retryMap[$errors[0]['reason']];
+    }
+
+    return 0;
   }
 }

--- a/src/Google/Task/Exception.php
+++ b/src/Google/Task/Exception.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+class Google_Task_Exception extends Google_Exception
+{
+}

--- a/src/Google/Task/Retryable.php
+++ b/src/Google/Task/Retryable.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * Interface for checking how many times a given task can be retried following
+ * a failure.
+ */
+interface Google_Task_Retryable
+{
+  /**
+   * Gets the number of times the associated task can be retried.
+   *
+   * NOTE: -1 is returned if the task can be retried indefinitely
+   *
+   * @return integer
+   */
+  public function allowedRetries();
+}

--- a/src/Google/Task/Runner.php
+++ b/src/Google/Task/Runner.php
@@ -1,0 +1,255 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require_once realpath(dirname(__FILE__) . '/../../../autoload.php');
+
+/**
+ * A task runner with exponential backoff support.
+ *
+ * @see https://developers.google.com/drive/web/handle-errors#implementing_exponential_backoff
+ */
+class Google_Task_Runner
+{
+  /**
+   * @var integer $maxDelay The max time (in seconds) to wait before a retry.
+   */
+  private $maxDelay = 60;
+  /**
+   * @var integer $delay The previous delay from which the next is calculated.
+   */
+  private $delay = 1;
+
+  /**
+   * @var integer $factor The base number for the exponential back off.
+   */
+  private $factor = 2;
+  /**
+   * @var float $jitter A random number between -$jitter and $jitter will be
+   * added to $factor on each iteration to allow for a better distribution of
+   * retries.
+   */
+  private $jitter = 0.5;
+
+  /**
+   * @var integer $attempts The number of attempts that have been tried so far.
+   */
+  private $attempts = 0;
+  /**
+   * @var integer $maxAttempts The max number of attempts allowed.
+   */
+  private $maxAttempts = 1;
+
+  /**
+   * @var Google_Client $client The current API client.
+   */
+  private $client;
+
+  /**
+   * @var string $name The name of the current task (used for logging).
+   */
+  private $name;
+  /**
+   * @var callable $action The task to run and possibly retry.
+   */
+  private $action;
+  /**
+   * @var array $arguments The task arguments.
+   */
+  private $arguments;
+
+  /**
+   * Creates a new task runner with exponential backoff support.
+   *
+   * @param Google_Client $client The current API client
+   * @param string $name The name of the current task (used for logging)
+   * @param callable $action The task to run and possibly retry
+   * @param array $arguments The task arguments
+   * @throws Google_Task_Exception when misconfigured
+   */
+  public function __construct(
+      Google_Client $client,
+      $name,
+      $action,
+      array $arguments = array()
+  ) {
+    $config = (array) $client->getClassConfig('Google_Task_Runner');
+
+    if (isset($config['initial_delay'])) {
+      if ($config['initial_delay'] < 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `initial_delay` must not be negative.'
+        );
+      }
+
+      $this->delay = $config['initial_delay'];
+    }
+
+    if (isset($config['max_delay'])) {
+      if ($config['max_delay'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `max_delay` must be greater than 0.'
+        );
+      }
+
+      $this->maxDelay = $config['max_delay'];
+    }
+
+    if (isset($config['factor'])) {
+      if ($config['factor'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `factor` must be greater than 0.'
+        );
+      }
+
+      $this->factor = $config['factor'];
+    }
+
+    if (isset($config['jitter'])) {
+      if ($config['jitter'] <= 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `jitter` must be greater than 0.'
+        );
+      }
+
+      $this->jitter = $config['jitter'];
+    }
+
+    if (isset($config['retries'])) {
+      if ($config['retries'] < 0) {
+        throw new Google_Task_Exception(
+            'Task configuration `retries` must not be negative.'
+        );
+      }
+      $this->maxAttempts += $config['retries'];
+    }
+
+    if (!is_callable($action)) {
+        throw new Google_Task_Exception(
+            'Task argument `$action` must be a valid callable.'
+        );
+    }
+
+    $this->name = $name;
+    $this->client = $client;
+    $this->action = $action;
+    $this->arguments = $arguments;
+  }
+
+  /**
+   * Checks if a retry can be attempted.
+   *
+   * @return boolean
+   */
+  public function canAttmpt()
+  {
+    return $this->attempts < $this->maxAttempts;
+  }
+
+  /**
+   * Runs the task and (if applicable) automatically retries when errors occur.
+   *
+   * @return mixed
+   * @throws Google_Task_Retryable on failure when no retries are available.
+   */
+  public function run()
+  {
+    while ($this->attempt()) {
+      try {
+        return call_user_func_array($this->action, $this->arguments);
+      } catch (Google_Task_Retryable $exception) {
+        $allowedRetries = $exception->allowedRetries();
+
+        if (!$this->canAttmpt() || !$allowedRetries) {
+          throw $exception;
+        }
+
+        if ($allowedRetries > 0) {
+          $this->maxAttempts = min(
+              $this->maxAttempts,
+              $this->attempts + $allowedRetries
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Runs a task once, if possible. This is useful for bypassing the `run()`
+   * loop.
+   *
+   * NOTE: If this is not the first attempt, this function will sleep in
+   * accordance to the backoff configurations before running the task.
+   *
+   * @return boolean
+   */
+  public function attempt()
+  {
+    if (!$this->canAttmpt()) {
+      return false;
+    }
+
+    if ($this->attempts > 0) {
+      $this->backOff();
+    }
+
+    $this->attempts++;
+    return true;
+  }
+
+  /**
+   * Sleeps in accordance to the backoff configurations.
+   */
+  private function backOff()
+  {
+    $delay = $this->getDelay();
+
+    $this->client->getLogger()->debug(
+        'Retrying task with backoff',
+        array(
+            'request' => $this->name,
+            'retry' => $this->attempts,
+            'backoff_seconds' => $delay
+        )
+    );
+
+    usleep($delay * 1000000);
+  }
+
+  /**
+   * Gets the delay (in seconds) for the current backoff period.
+   *
+   * @return float
+   */
+  private function getDelay()
+  {
+    $jitter = $this->getJitter();
+    $factor = $this->attempts > 1 ? $this->factor + $jitter : 1 + abs($jitter);
+
+    return $this->delay = min($this->maxDelay, $this->delay * $factor);
+  }
+
+  /**
+   * Gets the current jitter (random number between -$this->jitter and
+   * $this->jitter).
+   *
+   * @return float
+   */
+  private function getJitter()
+  {
+    return $this->jitter * 2 * mt_rand() / mt_getrandmax() - $this->jitter;
+  }
+}

--- a/tests/general/TaskTest.php
+++ b/tests/general/TaskTest.php
@@ -1,0 +1,754 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class TaskTest extends PHPUnit_Framework_TestCase
+{
+  private $client;
+
+  private $mockedCallsCount = 0;
+  private $currentMockedCall = 0;
+  private $mockedCalls = array();
+
+  protected function setUp()
+  {
+    $this->client = new Google_Client();
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   * @expectedException Google_Service_Exception
+   */
+  public function testRestRetryOffByDefault($errorCode, $errorBody = '{}')
+  {
+    $this->setNextResponse($errorCode, $errorBody)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   * @expectedException Google_Service_Exception
+   */
+  public function testOneRestRetryWithError($errorCode, $errorBody = '{}')
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $this->setNextResponses(2, $errorCode, $errorBody)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   * @expectedException Google_Service_Exception
+   */
+  public function testMultipleRestRetriesWithErrors(
+      $errorCode,
+      $errorBody = '{}'
+  ) {
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponses(6, $errorCode, $errorBody)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   */
+  public function testOneRestRetryWithSuccess($errorCode, $errorBody = '{}')
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $result = $this->setNextResponse($errorCode, $errorBody)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   */
+  public function testMultipleRestRetriesWithSuccess(
+      $errorCode,
+      $errorBody = '{}'
+  ) {
+    $this->setTaskConfig(array('retries' => 5));
+    $result = $this->setNextResponses(2, $errorCode, $errorBody)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @dataProvider defaultRestErrorProvider
+   * @expectedException Google_Service_Exception
+   */
+  public function testCustomRestRetryMapReplacesDefaults(
+      $errorCode,
+      $errorBody = '{}'
+  ) {
+    $this->client->setClassConfig(
+        'Google_Service_Exception',
+        array('retry_map' => array())
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponse($errorCode, $errorBody)->makeRequest();
+  }
+
+  public function testCustomRestRetryMapAddsNewHandlers()
+  {
+    $this->client->setClassConfig(
+        'Google_Service_Exception',
+        array('retry_map' => array('403' => Google_Config::TASK_RETRY_ALWAYS))
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $result = $this->setNextResponses(2, 403)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @expectedException Google_Service_Exception
+   * @dataProvider customLimitsProvider
+   */
+  public function testCustomRestRetryMapWithCustomLimits($limit)
+  {
+    $this->client->setClassConfig(
+        'Google_Service_Exception',
+        array('retry_map' => array('403' => $limit))
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponses($limit + 1, 403)->makeRequest();
+  }
+
+  /**
+   * @dataProvider timeoutProvider
+   */
+  public function testRestTimeouts($config, $minTime)
+  {
+    $this->setTaskConfig($config);
+    $this->setNextResponses($config['retries'], 500)
+         ->setNextResponse(200, '{"success": true}');
+
+    $this->assertTaskTimeGreaterThanOrEqual(
+        $minTime,
+        array($this, 'makeRequest'),
+        $config['initial_delay'] / 10
+    );
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   * @expectedException Google_IO_Exception
+   */
+  public function testCurlRetryOffByDefault($errorCode, $errorMessage = '')
+  {
+    $this->setNextResponseThrows($errorMessage, $errorCode)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   * @expectedException Google_IO_Exception
+   */
+  public function testOneCurlRetryWithError($errorCode, $errorMessage = '')
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $this->setNextResponsesThrow(2, $errorMessage, $errorCode)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   * @expectedException Google_IO_Exception
+   */
+  public function testMultipleCurlRetriesWithErrors(
+      $errorCode,
+      $errorMessage = ''
+  ) {
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponsesThrow(6, $errorMessage, $errorCode)->makeRequest();
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   */
+  public function testOneCurlRetryWithSuccess($errorCode, $errorMessage = '')
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $result = $this->setNextResponseThrows($errorMessage, $errorCode)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   */
+  public function testMultipleCurlRetriesWithSuccess(
+      $errorCode,
+      $errorMessage = ''
+  ) {
+    $this->setTaskConfig(array('retries' => 5));
+    $result = $this->setNextResponsesThrow(2, $errorMessage, $errorCode)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @dataProvider defaultCurlErrorProvider
+   * @expectedException Google_IO_Exception
+   */
+  public function testCustomCurlRetryMapReplacesDefaults(
+      $errorCode,
+      $errorMessage = ''
+  ) {
+    $this->client->setClassConfig(
+        'Google_IO_Exception',
+        array('retry_map' => array())
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponseThrows($errorMessage, $errorCode)->makeRequest();
+  }
+
+  public function testCustomCurlRetryMapAddsNewHandlers()
+  {
+    $this->client->setClassConfig(
+        'Google_IO_Exception',
+        array('retry_map' => array(
+            CURLE_COULDNT_RESOLVE_PROXY => Google_Config::TASK_RETRY_ALWAYS
+        ))
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $result = $this->setNextResponsesThrow(2, '', CURLE_COULDNT_RESOLVE_PROXY)
+                   ->setNextResponse(200, '{"success": true}')
+                   ->makeRequest();
+
+    $this->assertEquals(array("success" => true), $result);
+  }
+
+  /**
+   * @expectedException Google_IO_Exception
+   * @dataProvider customLimitsProvider
+   */
+  public function testCustomCurlRetryMapWithCustomLimits($limit)
+  {
+    $this->client->setClassConfig(
+        'Google_IO_Exception',
+        array('retry_map' => array(
+            CURLE_COULDNT_RESOLVE_PROXY => $limit
+        ))
+    );
+
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextResponsesThrow($limit + 1, '', CURLE_COULDNT_RESOLVE_PROXY)
+         ->makeRequest();
+  }
+
+  /**
+   * @dataProvider timeoutProvider
+   */
+  public function testCurlTimeouts($config, $minTime)
+  {
+    $this->setTaskConfig($config);
+    $this->setNextResponsesThrow($config['retries'], '', CURLE_GOT_NOTHING)
+         ->setNextResponse(200, '{"success": true}');
+
+    $this->assertTaskTimeGreaterThanOrEqual(
+        $minTime,
+        array($this, 'makeRequest'),
+        $config['initial_delay'] / 10
+    );
+  }
+
+  /**
+   * @dataProvider badTaskConfigProvider
+   */
+  public function testBadTaskConfig($config, $message)
+  {
+    $this->setExpectedException('Google_Task_Exception', $message);
+    $this->setTaskConfig($config);
+
+    new Google_Task_Runner(
+        $this->client,
+        '',
+        array($this, 'testBadTaskConfig')
+    );
+  }
+
+  /**
+   * @expectedException Google_Task_Exception
+   * @expectedExceptionMessage must be a valid callable
+   */
+  public function testBadTaskCallback()
+  {
+    new Google_Task_Runner($this->client, '', 5);
+  }
+
+  /**
+   * @expectedException Google_IO_Exception
+   */
+  public function testTaskRetryOffByDefault()
+  {
+    $this->setNextTaskAllowedRetries(Google_Config::TASK_RETRY_ALWAYS)
+         ->runTask();
+  }
+
+  /**
+   * @expectedException Google_IO_Exception
+   */
+  public function testOneTaskRetryWithError()
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $this->setNextTasksAllowedRetries(2, Google_Config::TASK_RETRY_ALWAYS)
+         ->runTask();
+  }
+
+  /**
+   * @expectedException Google_IO_Exception
+   */
+  public function testMultipleTaskRetriesWithErrors()
+  {
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextTasksAllowedRetries(6, Google_Config::TASK_RETRY_ALWAYS)
+         ->runTask();
+  }
+
+  public function testOneTaskRetryWithSuccess()
+  {
+    $this->setTaskConfig(array('retries' => 1));
+    $result = $this->setNextTaskAllowedRetries(Google_Config::TASK_RETRY_ALWAYS)
+                   ->setNextTaskReturnValue('success')
+                   ->runTask();
+
+    $this->assertEquals('success', $result);
+  }
+
+  public function testMultipleTaskRetriesWithSuccess()
+  {
+    $this->setTaskConfig(array('retries' => 5));
+    $result = $this->setNextTasksAllowedRetries(2, Google_Config::TASK_RETRY_ALWAYS)
+                   ->setNextTaskReturnValue('success')
+                   ->runTask();
+
+    $this->assertEquals('success', $result);
+  }
+
+  /**
+   * @expectedException Google_IO_Exception
+   * @dataProvider customLimitsProvider
+   */
+  public function testTaskRetryWithCustomLimits($limit)
+  {
+    $this->setTaskConfig(array('retries' => 5));
+    $this->setNextTasksAllowedRetries($limit + 1, $limit)
+         ->runTask();
+  }
+
+  /**
+   * @dataProvider timeoutProvider
+   */
+  public function testTaskTimeouts($config, $minTime)
+  {
+    $this->setTaskConfig($config);
+    $this->setNextTasksAllowedRetries($config['retries'], $config['retries'] + 1)
+         ->setNextTaskReturnValue('success');
+
+    $this->assertTaskTimeGreaterThanOrEqual(
+        $minTime,
+        array($this, 'runTask'),
+        $config['initial_delay'] / 10
+    );
+  }
+
+  public function testTaskWithManualRetries()
+  {
+    $this->setTaskConfig(array('retries' => 2));
+    $this->setNextTasksAllowedRetries(2, Google_Config::TASK_RETRY_ALWAYS);
+
+    $task = new Google_Task_Runner(
+        $this->client,
+        '',
+        array($this, 'runNextTask')
+    );
+
+    $this->assertTrue($task->canAttmpt());
+    $this->assertTrue($task->attempt());
+
+    $this->assertTrue($task->canAttmpt());
+    $this->assertTrue($task->attempt());
+
+    $this->assertTrue($task->canAttmpt());
+    $this->assertTrue($task->attempt());
+
+    $this->assertFalse($task->canAttmpt());
+    $this->assertFalse($task->attempt());
+  }
+
+  /**
+   * Provider for backoff configurations and expected minimum runtimes.
+   *
+   * @return array
+   */
+  public function timeoutProvider()
+  {
+    $config = array('initial_delay' => .001, 'max_delay' => .01);
+
+    return array(
+        array(array_merge($config, array('retries' => 1)), .001),
+        array(array_merge($config, array('retries' => 2)), .0015),
+        array(array_merge($config, array('retries' => 3)), .00225),
+        array(array_merge($config, array('retries' => 4)), .00375),
+        array(array_merge($config, array('retries' => 5)), .005625)
+    );
+  }
+
+  /**
+   * Provider for custom retry limits.
+   *
+   * @return array
+   */
+  public function customLimitsProvider()
+  {
+    return array(
+        array(Google_Config::TASK_RETRY_NEVER),
+        array(Google_Config::TASK_RETRY_ONCE),
+    );
+  }
+
+  /**
+   * Provider for invalid task configurations.
+   *
+   * @return array
+   */
+  public function badTaskConfigProvider()
+  {
+    return array(
+        array(array('initial_delay' => -1), 'must not be negative'),
+        array(array('max_delay' => 0), 'must be greater than 0'),
+        array(array('factor' => 0), 'must be greater than 0'),
+        array(array('jitter' => 0), 'must be greater than 0'),
+        array(array('retries' => -1), 'must not be negative')
+    );
+  }
+
+  /**
+   * Provider for the default REST errors.
+   *
+   * @return array
+   */
+  public function defaultRestErrorProvider()
+  {
+    return array(
+        array(500),
+        array(503),
+        array(403, '{"error":{"errors":[{"reason":"rateLimitExceeded"}]}}'),
+        array(403, '{"error":{"errors":[{"reason":"userRateLimitExceeded"}]}}'),
+    );
+  }
+
+  /**
+   * Provider for the default cURL errors.
+   *
+   * @return array
+   */
+  public function defaultCurlErrorProvider()
+  {
+    return array(
+        array(CURLE_COULDNT_RESOLVE_HOST),
+        array(CURLE_COULDNT_CONNECT),
+        array(CURLE_OPERATION_TIMEOUTED),
+        array(CURLE_SSL_CONNECT_ERROR),
+        array(CURLE_GOT_NOTHING),
+    );
+  }
+
+  /**
+   * Assert the minimum amount of time required to run a task.
+   *
+   * NOTE: Intentionally crude for brevity.
+   *
+   * @param float $expected The expected minimum execution time
+   * @param callable $callback The task to time
+   * @param float $delta Allowable relative error
+   *
+   * @throws PHPUnit_Framework_ExpectationFailedException
+   */
+  public static function assertTaskTimeGreaterThanOrEqual(
+      $expected,
+      $callback,
+      $delta = 0.0
+  ) {
+    $time = microtime(true);
+
+    call_user_func($callback);
+
+    self::assertThat(
+        microtime(true) - $time,
+        self::logicalOr(
+            self::greaterThan($expected),
+            self::equalTo($expected, $delta)
+        )
+    );
+  }
+
+  /**
+   * Sets the task runner configurations.
+   *
+   * @param array $config The task runner configurations
+   */
+  private function setTaskConfig(array $config)
+  {
+    $config += array(
+        'initial_delay' => .0001,
+        'max_delay' => .001,
+        'factor' => 2,
+        'jitter' => .5,
+        'retries' => 1
+    );
+    $this->client->setClassConfig('Google_Task_Runner', $config);
+  }
+
+  /**
+   * Sets the next responses.
+   *
+   * @param integer $count The number of responses
+   * @param string $code The response code
+   * @param string $body The response body
+   * @param array $headers The response headers
+   *
+   * @return TaskTest
+   */
+  private function setNextResponses(
+      $count,
+      $code = '200',
+      $body = '{}',
+      array $headers = array()
+  ) {
+    while ($count-- > 0) {
+      $this->setNextResponse($code, $body, $headers);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Sets the next response.
+   *
+   * @param string $code The response code
+   * @param string $body The response body
+   * @param array $headers The response headers
+   *
+   * @return TaskTest
+   */
+  private function setNextResponse(
+      $code = '200',
+      $body = '{}',
+      array $headers = array()
+  ) {
+    $this->mockedCalls[$this->mockedCallsCount++] = array(
+        'code' => (string) $code,
+        'headers' => $headers,
+        'body' => is_string($body) ? $body : json_encode($body)
+    );
+
+    return $this;
+  }
+
+  /**
+   * Forces the next responses to throw an IO exception.
+   *
+   * @param integer $count The number of responses
+   * @param string $message The exception messages
+   * @param string $code The exception code
+   *
+   * @return TaskTest
+   */
+  private function setNextResponsesThrow($count, $message, $code)
+  {
+    while ($count-- > 0) {
+      $this->setNextResponseThrows($message, $code);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Forces the next response to throw an IO exception.
+   *
+   * @param string $message The exception messages
+   * @param string $code The exception code
+   *
+   * @return TaskTest
+   */
+  private function setNextResponseThrows($message, $code)
+  {
+    $map = $this->client->getClassConfig('Google_IO_Exception', 'retry_map');
+    $this->mockedCalls[$this->mockedCallsCount++] = new Google_IO_Exception(
+        $message,
+        $code,
+        null,
+        $map
+    );
+
+    return $this;
+  }
+
+  /**
+   * Runs the defined request.
+   *
+   * @return array
+   */
+  private function makeRequest()
+  {
+    $request = new Google_Http_Request('/test');
+
+    $io = $this->getMockBuilder('Google_IO_Abstract')
+               ->disableOriginalConstructor()
+               ->setMethods(array('makeRequest'))
+               ->getMockForAbstractClass();
+
+    $io->expects($this->exactly($this->mockedCallsCount))
+       ->method('makeRequest')
+       ->will($this->returnCallback(array($this, 'getNextMockedCall')));
+
+    $this->client->setIo($io);
+
+    return Google_Http_REST::execute($this->client, $request);
+  }
+
+  /**
+   * Gets the next mocked response.
+   *
+   * @param Google_Http_Request $request The mocked request
+   *
+   * @return Google_Http_Request
+   */
+  public function getNextMockedCall($request)
+  {
+    $current = $this->mockedCalls[$this->currentMockedCall++];
+
+    if ($current instanceof Exception) {
+      throw $current;
+    }
+
+    $request->setResponseHttpCode($current['code']);
+    $request->setResponseHeaders($current['headers']);
+    $request->setResponseBody($current['body']);
+
+    return $request;
+  }
+
+  /**
+   * Sets the next task return value.
+   *
+   * @param mixed $value The next return value
+   *
+   * @return TaskTest
+   */
+  private function setNextTaskReturnValue($value)
+  {
+    $this->mockedCalls[$this->mockedCallsCount++] = $value;
+    return $this;
+  }
+
+  /**
+   * Sets the next exception `allowedRetries()` return value.
+   *
+   * @param boolean $allowedRetries The next `allowedRetries()` return value.
+   *
+   * @return TaskTest
+   */
+  private function setNextTaskAllowedRetries($allowedRetries)
+  {
+    $this->mockedCalls[$this->mockedCallsCount++] = $allowedRetries;
+    return $this;
+  }
+
+  /**
+   * Sets multiple exception `allowedRetries()` return value.
+   *
+   * @param integer $count The number of `allowedRetries()` return values.
+   * @param boolean $allowedRetries The `allowedRetries()` return value.
+   *
+   * @return TaskTest
+   */
+  private function setNextTasksAllowedRetries($count, $allowedRetries)
+  {
+    while ($count-- > 0) {
+      $this->setNextTaskAllowedRetries($allowedRetries);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Runs the defined task.
+   *
+   * @return mixed
+   */
+  private function runTask()
+  {
+    $task = new Google_Task_Runner(
+        $this->client,
+        '',
+        array($this, 'runNextTask')
+    );
+
+    $exception = $this->getMockBuilder('Google_IO_Exception')
+                      ->disableOriginalConstructor()
+                      ->setMethods(array('allowedRetries'))
+                      ->getMock();
+    $exceptionCount = 0;
+    $exceptionCalls = array();
+
+    for ($i = 0; $i < $this->mockedCallsCount; $i++) {
+      if (is_int($this->mockedCalls[$i])) {
+        $exceptionCalls[$exceptionCount++] = $this->mockedCalls[$i];
+        $this->mockedCalls[$i] = $exception;
+      }
+    }
+
+    $exception->expects($this->exactly($exceptionCount))
+              ->method('allowedRetries')
+              ->will(
+                  new PHPUnit_Framework_MockObject_Stub_ConsecutiveCalls(
+                      $exceptionCalls
+                  )
+              );
+
+    return $task->run();
+  }
+
+  /**
+   * Gets the next task return value.
+   *
+   * @return mixed
+   */
+  public function runNextTask()
+  {
+    $current = $this->mockedCalls[$this->currentMockedCall++];
+
+    if ($current instanceof Exception) {
+      throw $current;
+    }
+
+    return $current;
+  }
+}


### PR DESCRIPTION
This feature can be enabled by setting the `retries` configuration for the
`Google_Task_Runner` class:

``` php
$client = new Google_Client();
$client->setClassConfig('Google_Task_Runner', 'retries', 5);
```

Once `retries` is configured, the following error types will be retried by
default:
- Errors with a `500` or a `503` HTTP status code.
- Errors with a `rateLimitExceeded` or a `userRateLimitExceeded` reason type.
- cURL errors:
  - `CURLE_COULDNT_RESOLVE_HOST`
  - `CURLE_COULDNT_CONNECT`
  - `CURLE_OPERATION_TIMEOUTED`
  - `CURLE_SSL_CONNECT_ERROR`
  - `CURLE_GOT_NOTHING`

These error types can be configured using the `retry_map` configurations for
the `Google_IO_Exception` and `Google_Service_Exception` classes. The retry map
is an associative array which maps errors types to the number of times each
error can be retried (-1 can be used to retry an error indefinitely). For
example:

``` php
$client = new Google_Client();
$client->setClassConfig(
    'Google_Service_Exception',
    'retry_map',
    array(
        // Don't retry 500 errors
        '500' => 0,
        // Retry 503 errors once
        '503' => 1,
        // Retry rate limit errors until we hit `retries`
        'rateLimitExceeded' => -1,
        'userRateLimitExceeded' => -1
    )
);
```

For convenience, `Google_Config` provides three constants for configuring retry
limits: `Google_Config::TASK_RETRY_NEVER`, `Google_Config::TASK_RETRY_ONCE`, and
`Google_Config::TASK_RETRY_ALWAYS`.
