### PR TITLE
Tame redundant tests.

### DIFF
--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -47,19 +47,6 @@ class BaseTest extends PHPUnit_Framework_TestCase
     return $client;
   }
 
-  public function testClientConstructor()
-  {
-    $this->assertInstanceOf('Google_Client', $this->getClient());
-  }
-
-  public function testIncludes()
-  {
-    $path = dirname(dirname(__FILE__)) . '/src/Google/Service';
-    foreach (glob($path . "/*.php") as $file) {
-      $this->assertEquals(1, require_once($file));
-    }
-  }
-
   public function checkToken()
   {
     if (!strlen($this->token)) {

--- a/tests/general/ApiClientTest.php
+++ b/tests/general/ApiClientTest.php
@@ -34,6 +34,11 @@ class ApiClientTest extends BaseTest
     $this->assertEquals("{\"access_token\":\"1\"}", $client->getAccessToken());
   }
 
+  public function testClientConstructor()
+  {
+    $this->assertInstanceOf('Google_Client', $this->getClient());
+  }
+
   /**
    * @expectedException Google_Auth_Exception
    */

--- a/tests/general/ServiceTest.php
+++ b/tests/general/ServiceTest.php
@@ -31,7 +31,7 @@ class TestModel extends Google_Model
   }
 }
 
-class ServiceTest extends BaseTest
+class ServiceTest extends PHPUnit_Framework_TestCase
 {
   public function testModel()
   {
@@ -69,6 +69,28 @@ class ServiceTest extends BaseTest
 
     $this->assertEquals(true, $model->isAssociativeArray(array('test' => 'a')));
     $this->assertEquals(true, $model->isAssociativeArray(array("a", "b" => 2)));
+  }
+
+  /**
+   * @dataProvider serviceProvider
+   */
+  public function testIncludes($class)
+  {
+    $this->assertTrue(
+        class_exists($class),
+        sprintf('Failed asserting class %s exists.', $class)
+    );
+  }
+
+  public function serviceProvider()
+  {
+    $classes = array();
+    $path = dirname(dirname(dirname(__FILE__))) . '/src/Google/Service';
+    foreach (glob($path . "/*.php") as $file) {
+      $classes[] = array('Google_Service_' . basename($file, '.php'));
+    }
+
+    return $classes;
   }
 
   public function testStrLen()


### PR DESCRIPTION
All 18 test classes that extend `BaseTest` inherit the same two tests. A side
effect of this is that more than half of the assertions reported by PHPUnit
are from the same two test methods running over and over again.

I've refactored these test methods to live in more appropriate test classes.
I've also updated the `testIncludes` method to:
- Use a data provider so all failures will be printed at once.
- Give a nice error message instead of triggering a fatal error.
- Use the autoloader since that's the preferred method for including classes.
