### PR TITLE
Add the close quote to the href attribute, HTML doesn't display properly.

### DIFF
--- a/examples/simplefileupload.php
+++ b/examples/simplefileupload.php
@@ -107,7 +107,7 @@ if (
   <div class="request">
 <?php 
 if (isset($authUrl)) {
-  echo "<a class='login' href='" . $authUrl . ">Connect Me!</a>";
+  echo "<a class='login' href='" . $authUrl . "'>Connect Me!</a>";
 }
 ?>
   </div>


### PR DESCRIPTION
Simply closing the attribute in order to see the example properly in the browser.
