### PR TITLE
Correcting checking the expiration of the access token

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -456,6 +456,8 @@ class Google_Client
   {
     if (!$this->token) {
       return true;
+    } elseif (!isset($this->token['expires_in'])) {
+      return false;
     }
 
     $created = 0;

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -460,7 +460,9 @@ class Google_Client
   {
     if (!$this->token) {
       return true;
-    } elseif (!isset($this->token['expires_in'])) {
+    }
+    
+    if (!isset($this->token['expires_in'])) {
       return false;
     }
 


### PR DESCRIPTION
If you use the access token with the `offline` parameter, the timestamp is not returned by the server.

If you call the method `$client->isAccessTokenExpired()`, it always answers that the token expired.

Therefore, introduced changes that allow to correctly determine the "validity" of an unlimited access token.