### PR TITLE
PHP 7.2 compatibility update

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -47,7 +47,7 @@ class Google_Http_REST
     $runner = new Google_Task_Runner(
         $config,
         sprintf('%s %s', $request->getMethod(), (string) $request->getUri()),
-        array(get_class(), 'doExecute'),
+        array(__CLASS__, 'doExecute'),
         array($client, $request, $expectedClass)
     );
 


### PR DESCRIPTION
Calling `get_class()` without a parameter is no longer supported in PHP 7.2: https://secure.php.net/manual/en/function.get-class.php