### PR TITLE
Fix build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/google/google-api-php-client.svg?branch=master)](https://travis-ci.org/google/google-api-php-client)
+[![Build Status](https://travis-ci.org/googleapis/google-api-php-client.svg?branch=master)](https://travis-ci.org/googleapis/google-api-php-client)
 
 # Google APIs Client Library for PHP #
 


### PR DESCRIPTION
This fixes the currently broken Travis CI build status image in `README.md`. At some point, this repo was moved from the Google organization to the GoogleAPIs org, and the build status image was never updated.