### PR TITLE
Fix tests - expect getStatusCode to return a 200 code

### DIFF
--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -445,6 +445,9 @@ class Google_ClientTest extends BaseTest
       ->will($this->returnValue($token));
     if ($this->isGuzzle5()) {
       $response = $this->getMock('GuzzleHttp\Message\ResponseInterface');
+      $response->expects($this->once())
+        ->method('getStatusCode')
+        ->will($this->returnValue(200));
     } else {
       $response = $this->getMock('Psr\Http\Message\ResponseInterface');
     }
@@ -486,6 +489,9 @@ class Google_ClientTest extends BaseTest
       ->will($this->returnValue($token));
     if ($this->isGuzzle5()) {
       $response = $this->getMock('GuzzleHttp\Message\ResponseInterface');
+      $response->expects($this->once())
+        ->method('getStatusCode')
+        ->will($this->returnValue(200));
     } else {
       $response = $this->getMock('Psr\Http\Message\ResponseInterface');
     }
@@ -528,6 +534,9 @@ class Google_ClientTest extends BaseTest
       ->will($this->returnValue($token));
     if ($this->isGuzzle5()) {
       $response = $this->getMock('GuzzleHttp\Message\ResponseInterface');
+      $response->expects($this->once())
+        ->method('getStatusCode')
+        ->will($this->returnValue(200));
     } else {
       $response = $this->getMock('Psr\Http\Message\ResponseInterface');
     }


### PR DESCRIPTION
A patch in the `guzzlehttp/psr7` package now causes exceptions to be thrown when a `GuzzleHttp\Psr7\Response` object is instantiated without a valid status code.