### PR TITLE
Avoid throwing the exception on unlimited retries

### DIFF
--- a/src/Google/Task/Runner.php
+++ b/src/Google/Task/Runner.php
@@ -180,7 +180,7 @@ class Google_Task_Runner
             $exception->getErrors()
         );
 
-        if (!$this->canAttempt() || 0 !== $allowedRetries) {
+        if (!$this->canAttempt() || 0 === $allowedRetries) {
           throw $exception;
         }
 

--- a/src/Google/Task/Runner.php
+++ b/src/Google/Task/Runner.php
@@ -180,7 +180,7 @@ class Google_Task_Runner
             $exception->getErrors()
         );
 
-        if (!$this->canAttempt() || !$allowedRetries) {
+        if (!$this->canAttempt() || 0 !== $allowedRetries) {
           throw $exception;
         }
 


### PR DESCRIPTION
This fixes an issue where unlimited retries are impossible because -1 is an implicit false.