### PR TITLE
Fix order of arguments for implode in Google_Service_Resource

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -294,7 +294,7 @@ class Google_Service_Resource
     }
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;


### PR DESCRIPTION
For historical reasons `implode()` accepts its parameters in either order. However, PHP 7.4 now deprecates this. The glue should always be the first argument.

Note: this might be a good time to start testing against PHP 7.3 on Travis, as well as against 7.4, but with allowed failures.