### PR TITLE
tests: Upgrade unit tests for PHP 7.4 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 # Test lowest dependencies on PHP 5.4
 # (Guzzle 5.2, phpseclib 0.3)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ matrix:
   include:
     - php: 5.4
       env: COMPOSER_CMD="composer update phpseclib/phpseclib guzzlehttp/guzzle guzzlehttp/psr7 --prefer-lowest" RUN_PHP_CS=true
-  allow_failures:
-    - php: 7.4snapshot
 
 before_install:
   - composer self-update
@@ -41,10 +39,6 @@ before_install:
 install:
   - if [[ "$TRAVIS_PHP_VERSION" == "5.4" ]]; then composer remove --dev cache/filesystem-adapter; fi
   - $(echo $COMPOSER_CMD)
-
-before_script:
-  - phpenv version-name | grep ^5.[34] && echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
-  - phpenv version-name | grep ^5.[34] && echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.36",
+        "phpunit/phpunit": "^4.8|^5.0",
         "squizlabs/php_codesniffer": "~2.3",
         "symfony/dom-crawler": "~2.1",
         "symfony/css-selector": "~2.1",

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -242,4 +242,18 @@ class BaseTest extends TestCase
       $this->markTestSkipped('Guzzle 5 only');
     }
   }
+
+  protected function getGuzzle5ResponseMock()
+  {
+    $response = $this->prophesize('GuzzleHttp\Message\ResponseInterface');
+    $response->getStatusCode()
+        ->willReturn(200);
+
+    $response->getHeaders()->willReturn([]);
+    $response->getBody()->willReturn('');
+    $response->getProtocolVersion()->willReturn('');
+    $response->getReasonPhrase()->willReturn('');
+
+    return $response;
+  }
 }

--- a/tests/Google/AccessToken/VerifyTest.php
+++ b/tests/Google/AccessToken/VerifyTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use GuzzleHttp\Client;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
In older versions of PHPUnit, the mocking framework has fairly major compatibility issues with PHP 7.4, and due to (in my opinion) questionable decisions taken by the maintainers to not backport fixes to anyone using less than PHP 7.2, will not be taking action to address this in a way we can make use of.

This change replaces the PHPUnit mocks with prophecy mocks. ~~Once [this PR](https://github.com/phpspec/prophecy/pull/432) is tagged by prophecy, we will be able to remove the allow failures tag from PHP 7.4.~~ done.