### PR TITLE
feat: Move id token verification and revokation to auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,8 @@
     "license": "Apache-2.0",
     "require": {
         "php": ">=5.4",
-        "google/auth": "^1.0",
+        "google/auth": "^1.6",
         "google/apiclient-services": "~0.13",
-        "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~0.3.10||~2.0",
         "guzzlehttp/guzzle": "~5.3.1||~6.0",

--- a/src/Google/AccessToken/Revoke.php
+++ b/src/Google/AccessToken/Revoke.php
@@ -16,63 +16,47 @@
  * limitations under the License.
  */
 
+use Firebase\JWT\JWT;
+use Google\Auth\AccessToken;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\Request;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Wrapper around Google Access Tokens which provides convenience functions
  *
+ * @deprecated Use {@see Google\Auth\AccessToken}.
  */
 class Google_AccessToken_Revoke
 {
-  /**
-   * @var GuzzleHttp\ClientInterface The http client
-   */
-  private $http;
+    /**
+     * @var AccessToken
+     */
+    private $accessToken;
 
-  /**
-   * Instantiates the class, but does not initiate the login flow, leaving it
-   * to the discretion of the caller.
-   */
-  public function __construct(ClientInterface $http = null)
-  {
-    $this->http = $http;
-  }
-
-  /**
-   * Revoke an OAuth2 access token or refresh token. This method will revoke the current access
-   * token, if a token isn't provided.
-   *
-   * @param string|array $token The token (access token or a refresh token) that should be revoked.
-   * @return boolean Returns True if the revocation was successful, otherwise False.
-   */
-  public function revokeToken($token)
-  {
-    if (is_array($token)) {
-      if (isset($token['refresh_token'])) {
-        $token = $token['refresh_token'];
-      } else {
-        $token = $token['access_token'];
-      }
+    /**
+     * @param ClientInterface $http [optional] An HTTP Handler to deliver PSR-7 requests.
+     * @param CacheItemPoolInterface $cache [optional] A PSR-6 compatible cache implementation.
+     * @param AccessToken $accessToken [optional] An Access Token instance.
+     */
+    public function __construct(
+        ClientInterface $http = null,
+        CacheItemPoolInterface $cache = null,
+        AccessToken $accessToken = null
+    ) {
+        $httpHandler = HttpHandlerFactory::build($http);
+        $this->accessToken = $accessToken ?: new AccessToken($httpHandler, $cache);
     }
 
-    $body = Psr7\stream_for(http_build_query(array('token' => $token)));
-    $request = new Request(
-        'POST',
-        Google_Client::OAUTH2_REVOKE_URI,
-        [
-          'Cache-Control' => 'no-store',
-          'Content-Type'  => 'application/x-www-form-urlencoded',
-        ],
-        $body
-    );
-
-    $httpHandler = HttpHandlerFactory::build($this->http);
-
-    $response = $httpHandler($request);
-
-    return $response->getStatusCode() == 200;
-  }
+    /**
+     * Revoke an OAuth2 access token or refresh token. This method will revoke the current access
+     * token, if a token isn't provided.
+     *
+     * @param string|array $token The token (access token or a refresh token) that should be revoked.
+     * @return boolean Returns True if the revocation was successful, otherwise False.
+     */
+    public function revokeToken($token)
+    {
+        return $this->accessToken->revoke($token);
+    }
 }

--- a/src/Google/AccessToken/Verify.php
+++ b/src/Google/AccessToken/Verify.php
@@ -1,273 +1,96 @@
 <?php
 
 /*
- * Copyright 2008 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright 2008 Google Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
-use Firebase\JWT\SignatureInvalidException;
-use GuzzleHttp\Client;
+use Google\Auth\AccessToken;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\ClientInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Google\Auth\Cache\MemoryCacheItemPool;
-use Stash\Driver\FileSystem;
-use Stash\Pool;
 
 /**
  * Wrapper around Google Access Tokens which provides convenience functions
  *
+ * @deprecated Use {@see Google\Auth\AccessToken}.
  */
 class Google_AccessToken_Verify
 {
-  const FEDERATED_SIGNON_CERT_URL = 'https://www.googleapis.com/oauth2/v3/certs';
-  const OAUTH2_ISSUER = 'accounts.google.com';
-  const OAUTH2_ISSUER_HTTPS = 'https://accounts.google.com';
+    const FEDERATED_SIGNON_CERT_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+    const OAUTH2_ISSUER = 'accounts.google.com';
+    const OAUTH2_ISSUER_HTTPS = 'https://accounts.google.com';
 
-  /**
-   * @var GuzzleHttp\ClientInterface The http client
-   */
-  private $http;
+    /**
+     * @var AccessToken
+     */
+    private $accessToken;
 
-  /**
-   * @var Psr\Cache\CacheItemPoolInterface cache class
-   */
-  private $cache;
+    /**
+     * Formerly implicit public property. maintain for backwards compatibility.
+     *
+     * @deprecated
+     * @var Jwt|null
+     */
+    public $jwt;
 
-  /**
-   * Instantiates the class, but does not initiate the login flow, leaving it
-   * to the discretion of the caller.
-   */
-  public function __construct(
-      ClientInterface $http = null,
-      CacheItemPoolInterface $cache = null,
-      $jwt = null
-  ) {
-    if (null === $http) {
-      $http = new Client();
+    /**
+     * @param ClientInterface $httpHandler [optional] An HTTP Handler to deliver PSR-7 requests.
+     * @param CacheItemPoolInterface $cache [optional] A PSR-6 compatible cache implementation.
+     * @param Firebase\JWT\JWT|\JWT [optional] DEPRECATED.
+     * @param AccessToken $accessToken [optional] An Access Token instance.
+     */
+    public function __construct(
+        ClientInterface $http = null,
+        CacheItemPoolInterface $cache = null,
+        $jwt = null,
+        AccessToken $accessToken = null
+    ) {
+        $httpHandler = HttpHandlerFactory::build($http);
+        $this->accessToken = $accessToken ?: new AccessToken($httpHandler, $cache);
+
+        // For backwards compatibility.
+        $this->jwt = $jwt ?: $this->getJwtService();
     }
 
-    if (null === $cache) {
-      $cache = new MemoryCacheItemPool;
+    /**
+     * Verifies an id token and returns the authenticated apiLoginTicket.
+     * Throws an exception if the id token is not valid.
+     * The audience parameter can be used to control which id tokens are
+     * accepted.  By default, the id token must have been issued to this OAuth2 client.
+     *
+     * @param string $token The JSON Web Token to be verified.
+     * @param string [optional] $audience The indended recipient of the token.
+     * @return array the token payload, if successful
+     */
+    public function verifyIdToken($idToken, $audience = null)
+    {
+        return $this->accessToken->verify($idToken, $audience);
     }
 
-    $this->http = $http;
-    $this->cache = $cache;
-    $this->jwt = $jwt ?: $this->getJwtService();
-  }
-
-  /**
-   * Verifies an id token and returns the authenticated apiLoginTicket.
-   * Throws an exception if the id token is not valid.
-   * The audience parameter can be used to control which id tokens are
-   * accepted.  By default, the id token must have been issued to this OAuth2 client.
-   *
-   * @param $audience
-   * @return array the token payload, if successful
-   */
-  public function verifyIdToken($idToken, $audience = null)
-  {
-    if (empty($idToken)) {
-      throw new LogicException('id_token cannot be null');
-    }
-
-    // set phpseclib constants if applicable
-    $this->setPhpsecConstants();
-
-    // Check signature
-    $certs = $this->getFederatedSignOnCerts();
-    foreach ($certs as $cert) {
-      $bigIntClass = $this->getBigIntClass();
-      $rsaClass = $this->getRsaClass();
-      $modulus = new $bigIntClass($this->jwt->urlsafeB64Decode($cert['n']), 256);
-      $exponent = new $bigIntClass($this->jwt->urlsafeB64Decode($cert['e']), 256);
-
-      $rsa = new $rsaClass();
-      $rsa->loadKey(array('n' => $modulus, 'e' => $exponent));
-
-      try {
-        $payload = $this->jwt->decode(
-            $idToken,
-            $rsa->getPublicKey(),
-            array('RS256')
-        );
-
-        if (property_exists($payload, 'aud')) {
-          if ($audience && $payload->aud != $audience) {
-            return false;
-          }
+    /**
+     * Maintained for backwards compatibility on Verify::$jwt.
+     *
+     * @return \Firebase\JWT\JWT|\JWT
+     */
+    private function getJwtService()
+    {
+        $jwtClass = 'JWT';
+        if (class_exists('\Firebase\JWT\JWT')) {
+            $jwtClass = 'Firebase\JWT\JWT';
         }
 
-        // support HTTP and HTTPS issuers
-        // @see https://developers.google.com/identity/sign-in/web/backend-auth
-        $issuers = array(self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS);
-        if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
-          return false;
-        }
-
-        return (array) $payload;
-      } catch (ExpiredException $e) {
-        return false;
-      } catch (ExpiredExceptionV3 $e) {
-        return false;
-      } catch (SignatureInvalidException $e) {
-        // continue
-      } catch (DomainException $e) {
-        // continue
-      }
+        return new $jwtClass;
     }
-
-    return false;
-  }
-
-  private function getCache()
-  {
-    return $this->cache;
-  }
-
-  /**
-   * Retrieve and cache a certificates file.
-   *
-   * @param $url string location
-   * @throws Google_Exception
-   * @return array certificates
-   */
-  private function retrieveCertsFromLocation($url)
-  {
-    // If we're retrieving a local file, just grab it.
-    if (0 !== strpos($url, 'http')) {
-      if (!$file = file_get_contents($url)) {
-        throw new Google_Exception(
-            "Failed to retrieve verification certificates: '" .
-            $url . "'."
-        );
-      }
-
-      return json_decode($file, true);
-    }
-
-    $response = $this->http->get($url);
-
-    if ($response->getStatusCode() == 200) {
-      return json_decode((string) $response->getBody(), true);
-    }
-    throw new Google_Exception(
-        sprintf(
-            'Failed to retrieve verification certificates: "%s".',
-            $response->getBody()->getContents()
-        ),
-        $response->getStatusCode()
-    );
-  }
-
-  // Gets federated sign-on certificates to use for verifying identity tokens.
-  // Returns certs as array structure, where keys are key ids, and values
-  // are PEM encoded certificates.
-  private function getFederatedSignOnCerts()
-  {
-    $certs = null;
-    if ($cache = $this->getCache()) {
-      $cacheItem = $cache->getItem('federated_signon_certs_v3');
-      $certs = $cacheItem->get();
-    }
-
-
-    if (!$certs) {
-      $certs = $this->retrieveCertsFromLocation(
-          self::FEDERATED_SIGNON_CERT_URL
-      );
-
-      if ($cache) {
-        $cacheItem->expiresAt(new DateTime('+1 hour'));
-        $cacheItem->set($certs);
-        $cache->save($cacheItem);
-      }
-    }
-
-    if (!isset($certs['keys'])) {
-      throw new InvalidArgumentException(
-          'federated sign-on certs expects "keys" to be set'
-      );
-    }
-
-    return $certs['keys'];
-  }
-
-  private function getJwtService()
-  {
-    $jwtClass = 'JWT';
-    if (class_exists('\Firebase\JWT\JWT')) {
-      $jwtClass = 'Firebase\JWT\JWT';
-    }
-
-    if (property_exists($jwtClass, 'leeway') && $jwtClass::$leeway < 1) {
-      // Ensures JWT leeway is at least 1
-      // @see https://github.com/google/google-api-php-client/issues/827
-      $jwtClass::$leeway = 1;
-    }
-
-    return new $jwtClass;
-  }
-
-  private function getRsaClass()
-  {
-    if (class_exists('phpseclib\Crypt\RSA')) {
-      return 'phpseclib\Crypt\RSA';
-    }
-
-    return 'Crypt_RSA';
-  }
-
-  private function getBigIntClass()
-  {
-    if (class_exists('phpseclib\Math\BigInteger')) {
-      return 'phpseclib\Math\BigInteger';
-    }
-
-    return 'Math_BigInteger';
-  }
-
-  private function getOpenSslConstant()
-  {
-    if (class_exists('phpseclib\Crypt\RSA')) {
-      return 'phpseclib\Crypt\RSA::MODE_OPENSSL';
-    }
-
-    if (class_exists('Crypt_RSA')) {
-      return 'CRYPT_RSA_MODE_OPENSSL';
-    }
-
-    throw new \Exception('Cannot find RSA class');
-  }
-
-  /**
-   * phpseclib calls "phpinfo" by default, which requires special
-   * whitelisting in the AppEngine VM environment. This function
-   * sets constants to bypass the need for phpseclib to check phpinfo
-   *
-   * @see phpseclib/Math/BigInteger
-   * @see https://github.com/GoogleCloudPlatform/getting-started-php/issues/85
-   */
-  private function setPhpsecConstants()
-  {
-    if (filter_var(getenv('GAE_VM'), FILTER_VALIDATE_BOOLEAN)) {
-      if (!defined('MATH_BIGINTEGER_OPENSSL_ENABLED')) {
-        define('MATH_BIGINTEGER_OPENSSL_ENABLED', true);
-      }
-      if (!defined('CRYPT_RSA_MODE')) {
-        define('CRYPT_RSA_MODE', constant($this->getOpenSslConstant()));
-      }
-    }
-  }
 }

--- a/tests/Google/AccessToken/RevokeTest.php
+++ b/tests/Google/AccessToken/RevokeTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use GuzzleHttp\Client;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -23,128 +21,17 @@ use GuzzleHttp\Client;
 
 class Google_AccessToken_RevokeTest extends BaseTest
 {
-  public function testRevokeAccessGuzzle5()
-  {
-    $this->onlyGuzzle5();
+    public function testRevoke()
+    {
+        $token = 'foobar';
+        $result = ['a' => 'b'];
 
-    $accessToken = 'ACCESS_TOKEN';
-    $refreshToken = 'REFRESH_TOKEN';
-    $token = '';
+        $accessToken = $this->prophesize('Google\Auth\AccessToken');
+        $accessToken->revoke($token)
+            ->shouldBeCalled()
+            ->willReturn($result);
 
-    $response = $this->getMock('GuzzleHttp\Message\ResponseInterface');
-    $response->expects($this->exactly(3))
-      ->method('getStatusCode')
-      ->will($this->returnValue(200));
-    $http = $this->getMock('GuzzleHttp\ClientInterface');
-    $http->expects($this->exactly(3))
-      ->method('send')
-      ->will($this->returnCallback(
-            function ($request) use (&$token, $response) {
-              parse_str((string) $request->getBody(), $fields);
-              $token = isset($fields['token']) ? $fields['token'] : null;
-
-              return $response;
-            }
-        ));
-
-    $requestToken = null;
-    $request = $this->getMock('GuzzleHttp\Message\RequestInterface');
-    $request->expects($this->exactly(3))
-        ->method('getBody')
-        ->will($this->returnCallback(
-            function () use (&$requestToken) {
-              return 'token='.$requestToken;
-            }));
-    $http->expects($this->exactly(3))
-      ->method('createRequest')
-      ->will($this->returnCallback(
-            function ($method, $url, $params) use (&$requestToken, $request) {
-              parse_str((string) $params['body'], $fields);
-              $requestToken = isset($fields['token']) ? $fields['token'] : null;
-
-              return $request;
-            }
-        ));
-
-    $t = array(
-      'access_token' => $accessToken,
-      'created' => time(),
-      'expires_in' => '3600'
-    );
-
-    // Test with access token.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($accessToken, $token);
-
-    // Test with refresh token.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $t = array(
-      'access_token' => $accessToken,
-      'refresh_token' => $refreshToken,
-      'created' => time(),
-      'expires_in' => '3600'
-    );
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($refreshToken, $token);
-
-    // Test with token string.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $t = $accessToken;
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($accessToken, $token);
-  }
-
-  public function testRevokeAccessGuzzle6()
-  {
-    $this->onlyGuzzle6();
-
-    $accessToken = 'ACCESS_TOKEN';
-    $refreshToken = 'REFRESH_TOKEN';
-    $token = '';
-
-    $response = $this->getMock('Psr\Http\Message\ResponseInterface');
-    $response->expects($this->exactly(3))
-      ->method('getStatusCode')
-      ->will($this->returnValue(200));
-    $http = $this->getMock('GuzzleHttp\ClientInterface');
-    $http->expects($this->exactly(3))
-      ->method('send')
-      ->will($this->returnCallback(
-            function ($request) use (&$token, $response) {
-              parse_str((string) $request->getBody(), $fields);
-              $token = isset($fields['token']) ? $fields['token'] : null;
-
-              return $response;
-            }
-        ));
-
-    $t = array(
-      'access_token' => $accessToken,
-      'created' => time(),
-      'expires_in' => '3600'
-    );
-
-    // Test with access token.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($accessToken, $token);
-
-    // Test with refresh token.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $t = array(
-      'access_token' => $accessToken,
-      'refresh_token' => $refreshToken,
-      'created' => time(),
-      'expires_in' => '3600'
-    );
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($refreshToken, $token);
-
-    // Test with token string.
-    $revoke = new Google_AccessToken_Revoke($http);
-    $t = $accessToken;
-    $this->assertTrue($revoke->revokeToken($t));
-    $this->assertEquals($accessToken, $token);
-  }
+        $revoke = new Google_AccessToken_Revoke(null, null, $accessToken->reveal());
+        $this->assertEquals($result, $revoke->revokeToken($token));
+    }
 }

--- a/tests/Google/AccessToken/VerifyTest.php
+++ b/tests/Google/AccessToken/VerifyTest.php
@@ -1,7 +1,4 @@
 <?php
-
-use GuzzleHttp\Client;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,132 +18,141 @@ use GuzzleHttp\Client;
  * under the License.
  */
 
+ /**
+  * @group access-token
+  */
 class Google_AccessToken_VerifyTest extends BaseTest
 {
-  /**
-   * This test needs to run before the other verify tests,
-   * to ensure the constants are not defined.
-   */
-  public function testPhpsecConstants()
-  {
-    $client = $this->getClient();
-    $verify = new Google_AccessToken_Verify($client->getHttpClient());
+    public function testVerify()
+    {
+        $token = 'a.b.c';
+        $audience = 'aud';
+        $result = ['a' => 'b'];
 
-    // set these to values that will be changed
-    if (defined('MATH_BIGINTEGER_OPENSSL_ENABLED') || defined('CRYPT_RSA_MODE')) {
-      $this->markTestSkipped('Cannot run test - constants already defined');
+        $accessToken = $this->prophesize('Google\Auth\AccessToken');
+        $accessToken->verify($token, $audience)
+            ->shouldBeCalled()
+            ->willReturn($result);
+
+        $verify = new Google_AccessToken_Verify(null, null, null, $accessToken->reveal());
+        $this->assertEquals($result, $verify->verifyIdToken($token, $audience));
     }
 
-    // Pretend we are on App Engine VMs
-    putenv('GAE_VM=1');
+    /**
+     * This test needs to run before the other verify tests,
+     * to ensure the constants are not defined.
+     */
+    public function testPhpsecConstants()
+    {
+        $client = $this->getClient();
+        $verify = new Google_AccessToken_Verify($client->getHttpClient());
 
-    $verify->verifyIdToken('a.b.c');
+        // set these to values that will be changed
+        if (defined('MATH_BIGINTEGER_OPENSSL_ENABLED') || defined('CRYPT_RSA_MODE')) {
+            $this->markTestSkipped('Cannot run test - constants already defined');
+        }
 
-    putenv('GAE_VM=0');
+        // Pretend we are on App Engine VMs
+        putenv('GAE_VM=1');
 
-    $openSslEnable = constant('MATH_BIGINTEGER_OPENSSL_ENABLED');
-    $rsaMode = constant('CRYPT_RSA_MODE');
-    $this->assertTrue($openSslEnable);
-    $this->assertEquals(constant($this->getOpenSslConstant()), $rsaMode);
-  }
+        $verify->verifyIdToken('a.b.c');
 
-  /**
-   * Most of the logic for ID token validation is in AuthTest -
-   * this is just a general check to ensure we verify a valid
-   * id token if one exists.
-   */
-  public function testValidateIdToken()
-  {
-    $this->checkToken();
+        putenv('GAE_VM=0');
 
-    $jwt = $this->getJwtService();
-    $client = $this->getClient();
-    $http = $client->getHttpClient();
-    $token = $client->getAccessToken();
-    if ($client->isAccessTokenExpired()) {
-      $token = $client->fetchAccessTokenWithRefreshToken();
-    }
-    $segments = explode('.', $token['id_token']);
-    $this->assertCount(3, $segments);
-    // Extract the client ID in this case as it wont be set on the test client.
-    $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
-    $verify = new Google_AccessToken_Verify($http);
-    $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
-    $this->assertArrayHasKey('sub', $payload);
-    $this->assertGreaterThan(0, strlen($payload['sub']));
-
-    // TODO: Need to be smart about testing/disabling the
-    // caching for this test to make sense. Not sure how to do that
-    // at the moment.
-    $client = $this->getClient();
-    $http = $client->getHttpClient();
-    $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
-    $verify = new Google_AccessToken_Verify($http);
-    $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
-    $this->assertArrayHasKey('sub', $payload);
-    $this->assertGreaterThan(0, strlen($payload['sub']));
-  }
-
-  /**
-   * Most of the logic for ID token validation is in AuthTest -
-   * this is just a general check to ensure we verify a valid
-   * id token if one exists.
-   */
-  public function testLeewayIsUnchangedWhenPassingInJwt()
-  {
-    $this->checkToken();
-
-    $jwt = $this->getJwtService();
-    // set arbitrary leeway so we can check this later
-    $jwt::$leeway = $leeway = 1.5;
-    $client = $this->getClient();
-    $token = $client->getAccessToken();
-    if ($client->isAccessTokenExpired()) {
-      $token = $client->fetchAccessTokenWithRefreshToken();
-    }
-    $segments = explode('.', $token['id_token']);
-    $this->assertCount(3, $segments);
-    // Extract the client ID in this case as it wont be set on the test client.
-    $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
-    $verify = new Google_AccessToken_Verify($client->getHttpClient(), null, $jwt);
-    $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
-    // verify the leeway is set as it was
-    $this->assertEquals($leeway, $jwt::$leeway);
-  }
-
-  public function testRetrieveCertsFromLocation()
-  {
-    $client = $this->getClient();
-    $verify = new Google_AccessToken_Verify($client->getHttpClient());
-
-    // make this method public for testing purposes
-    $method = new ReflectionMethod($verify, 'retrieveCertsFromLocation');
-    $method->setAccessible(true);
-    $certs = $method->invoke($verify, Google_AccessToken_Verify::FEDERATED_SIGNON_CERT_URL);
-
-    $this->assertArrayHasKey('keys', $certs);
-    $this->assertGreaterThan(1, count($certs['keys']));
-    $this->assertArrayHasKey('alg', $certs['keys'][0]);
-    $this->assertEquals('RS256', $certs['keys'][0]['alg']);
-  }
-
-  private function getJwtService()
-  {
-    if (class_exists('\Firebase\JWT\JWT')) {
-      return new \Firebase\JWT\JWT;
+        $openSslEnable = constant('MATH_BIGINTEGER_OPENSSL_ENABLED');
+        $rsaMode = constant('CRYPT_RSA_MODE');
+        $this->assertTrue($openSslEnable);
+        $this->assertEquals(constant($this->getOpenSslConstant()), $rsaMode);
     }
 
-    return new \JWT;
-  }
+    /**
+     * Most of the logic for ID token validation is in AuthTest -
+     * this is just a general check to ensure we verify a valid
+     * id token if one exists.
+     */
+    public function testValidateIdToken()
+    {
+        $this->checkToken();
 
-  private function getOpenSslConstant()
-  {
-    if (class_exists('phpseclib\Crypt\RSA')) {
-      return 'phpseclib\Crypt\RSA::MODE_OPENSSL';
+        $jwt = $this->getJwtService();
+        $client = $this->getClient();
+        $http = $client->getHttpClient();
+        $token = $client->getAccessToken();
+
+        if ($client->isAccessTokenExpired()) {
+            $token = $client->fetchAccessTokenWithRefreshToken();
+        }
+
+        $segments = explode('.', $token['id_token']);
+        $this->assertCount(3, $segments);
+
+        // Extract the client ID in this case as it wont be set on the test client.
+        $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
+        $verify = new Google_AccessToken_Verify($http);
+        $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
+        $this->assertArrayHasKey('sub', $payload);
+        $this->assertGreaterThan(0, strlen($payload['sub']));
+
+        // TODO: Need to be smart about testing/disabling the
+        // caching for this test to make sense. Not sure how to do that
+        // at the moment.
+        $client = $this->getClient();
+        $http = $client->getHttpClient();
+        $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
+        $verify = new Google_AccessToken_Verify($http);
+        $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
+        $this->assertArrayHasKey('sub', $payload);
+        $this->assertGreaterThan(0, strlen($payload['sub']));
     }
 
-    if (class_exists('Crypt_RSA')) {
-      return 'CRYPT_RSA_MODE_OPENSSL';
+    /**
+     * Most of the logic for ID token validation is in AuthTest -
+     * this is just a general check to ensure we verify a valid
+     * id token if one exists.
+     */
+    public function testLeewayIsUnchangedWhenPassingInJwt()
+    {
+        $this->checkToken();
+
+        $jwt = $this->getJwtService();
+        // set arbitrary leeway so we can check this later
+        $jwt::$leeway = $leeway = 1.5;
+        $client = $this->getClient();
+        $token = $client->getAccessToken();
+
+        if ($client->isAccessTokenExpired()) {
+            $token = $client->fetchAccessTokenWithRefreshToken();
+        }
+
+        $segments = explode('.', $token['id_token']);
+        $this->assertCount(3, $segments);
+
+        // Extract the client ID in this case as it wont be set on the test client.
+        $data = json_decode($jwt->urlSafeB64Decode($segments[1]));
+        $verify = new Google_AccessToken_Verify($client->getHttpClient(), null, $jwt);
+        $payload = $verify->verifyIdToken($token['id_token'], $data->aud);
+
+        // verify the leeway is set as it was
+        $this->assertEquals($leeway, $jwt::$leeway);
     }
-  }
+
+    private function getJwtService()
+    {
+        if (class_exists('\Firebase\JWT\JWT')) {
+            return new \Firebase\JWT\JWT;
+        }
+
+        return new \JWT;
+    }
+
+    private function getOpenSslConstant()
+    {
+        if (class_exists('phpseclib\Crypt\RSA')) {
+            return 'phpseclib\Crypt\RSA::MODE_OPENSSL';
+        }
+
+        if (class_exists('Crypt_RSA')) {
+            return 'CRYPT_RSA_MODE_OPENSSL';
+        }
+    }
 }


### PR DESCRIPTION
In order to re-consolidate all access token utilities after [google/auth#243](https://github.com/googleapis/google-auth-library-php/pull/243) was released, this PR migrates token verification to auth in a non-breaking manner.