### PR TITLE
docs: update readme with info on services repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ If you're installing this library for authentication or other purposes which do 
 
 ```json
 {
-    "provide": {
-        "google/apiclient-services": "*"
+    "replace": {
+        "google/apiclient-services": "self.version"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Finally, be sure to include the autoloader:
 require_once '/path/to/your-project/vendor/autoload.php';
 ```
 
+This library relies on `google/apiclient-services`. That library provides up-to-date API wrappers for a large number of Google APIs. In order that users may make use of the latest API clients, this library does not pin to a specific version of `google/apiclient-services`. **In order to prevent the accidental installation of API wrappers with breaking changes**, it is highly recommended that you pin to the latest version yourself prior to using this library in production.
+
+If you're installing this library for authentication or other purposes which do not require the API wrappers, you may prevent their installation by adding the following to your project's `composer.json` file:
+
+```json
+{
+    "provide": {
+        "google/apiclient-services": "*"
+    }
+}
+```
+
 ### Download the Release
 
 If you prefer not to use composer, you can download the package in its entirety. The [Releases](https://github.com/googleapis/google-api-php-client/releases) page lists all stable versions. Download any file

--- a/README.md
+++ b/README.md
@@ -43,16 +43,6 @@ require_once '/path/to/your-project/vendor/autoload.php';
 
 This library relies on `google/apiclient-services`. That library provides up-to-date API wrappers for a large number of Google APIs. In order that users may make use of the latest API clients, this library does not pin to a specific version of `google/apiclient-services`. **In order to prevent the accidental installation of API wrappers with breaking changes**, it is highly recommended that you pin to the latest version yourself prior to using this library in production.
 
-If you're installing this library for authentication or other purposes which do not require the API wrappers, you may prevent their installation by adding the following to your project's `composer.json` file:
-
-```json
-{
-    "replace": {
-        "google/apiclient-services": "self.version"
-    }
-}
-```
-
 ### Download the Release
 
 If you prefer not to use composer, you can download the package in its entirety. The [Releases](https://github.com/googleapis/google-api-php-client/releases) page lists all stable versions. Download any file
@@ -253,6 +243,8 @@ The method used is a matter of preference, but *it will be very difficult to use
 ### Making HTTP Requests Directly ###
 
 If Google Authentication is desired for external applications, or a Google API is not available yet in this library, HTTP requests can be made directly.
+
+If you are installing this client only to authenticate your own HTTP client requests, you should use [`google/auth`](https://github.com/googleapis/google-auth-library-php#call-the-apis) instead.
 
 The `authorize` method returns an authorized [Guzzle Client](http://docs.guzzlephp.org/), so any request made using the client will contain the corresponding authorization.
 


### PR DESCRIPTION
This change adds a warning to users to pin to a specific version of `google/apiclient-services` and also a guide to how they can skip installation of services if they don't need them.