### PR TITLE
chore: update ignored files for exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
+/CODE_OF_CONDUCT.md
+/docs export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore
 /phpcs.xml.dist export-ignore


### PR DESCRIPTION
This commit is part of a campaign to reduce the amount of data transferred to save global bandwidth and reduce the amount of CO2. See https://github.com/Codeception/Codeception/pull/5527 for more info.

I don't see any reason why the docs folder should be part of the zip archive. If this is needed for other cases, please let me know.