### PR TITLE
Support Guzzle7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
   include:
     - php: 5.4
       env: COMPOSER_CMD="composer update phpseclib/phpseclib guzzlehttp/guzzle guzzlehttp/psr7 --prefer-lowest" RUN_PHP_CS=true
+    - php: 7.4
+      env: COMPOSER_CMD="composer update guzzlehttp/guzzle:^6.5"
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
   include:
     - php: 5.4
       env: COMPOSER_CMD="composer update phpseclib/phpseclib guzzlehttp/guzzle guzzlehttp/psr7 --prefer-lowest" RUN_PHP_CS=true
-    - php: 7.4
-      env: COMPOSER_CMD="composer update guzzlehttp/guzzle:^6.5"
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~0.3.10||~2.0",
-        "guzzlehttp/guzzle": "~5.3.1||~6.0",
+        "guzzlehttp/guzzle": "~5.3.1||~6.0||~7.0",
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,12 @@
     "keywords": ["google"],
     "homepage": "http://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
+    "repositories": [
+        { "type": "vcs", "url": "https://github.com/jeromegamez/google-auth-library-php"}
+    ],
     "require": {
         "php": ">=5.4",
-        "google/auth": "^1.9",
+        "google/auth": "dev-guzzle7 as 1.10",
         "google/apiclient-services": "~0.13",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",

--- a/src/Google/AuthHandler/AuthHandlerFactory.php
+++ b/src/Google/AuthHandler/AuthHandlerFactory.php
@@ -28,12 +28,18 @@ class Google_AuthHandler_AuthHandlerFactory
    */
   public static function build($cache = null, array $cacheConfig = [])
   {
-    $version = ClientInterface::VERSION;
+      $guzzleVersion = null;
+      if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+          $guzzleVersion = ClientInterface::MAJOR_VERSION;
+      } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+          $guzzleVersion = (int) substr(ClientInterface::VERSION, 0, 1);
+      }
 
-    switch ($version[0]) {
-      case '5':
+    switch ($guzzleVersion) {
+      case 5:
         return new Google_AuthHandler_Guzzle5AuthHandler($cache, $cacheConfig);
-      case '6':
+      case 6:
+      case 7:
         return new Google_AuthHandler_Guzzle6AuthHandler($cache, $cacheConfig);
       default:
         throw new Exception('Version not supported');

--- a/src/Google/AuthHandler/AuthHandlerFactory.php
+++ b/src/Google/AuthHandler/AuthHandlerFactory.php
@@ -29,11 +29,11 @@ class Google_AuthHandler_AuthHandlerFactory
   public static function build($cache = null, array $cacheConfig = [])
   {
       $guzzleVersion = null;
-      if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
-          $guzzleVersion = ClientInterface::MAJOR_VERSION;
-      } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-          $guzzleVersion = (int) substr(ClientInterface::VERSION, 0, 1);
-      }
+    if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+      $guzzleVersion = ClientInterface::MAJOR_VERSION;
+    } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+      $guzzleVersion = (int) substr(ClientInterface::VERSION, 0, 1);
+    }
 
     switch ($guzzleVersion) {
       case 5:

--- a/src/Google/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/Google/AuthHandler/Guzzle6AuthHandler.php
@@ -11,7 +11,7 @@ use GuzzleHttp\ClientInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
-*
+* This supports both Guzzle 6 and 7.
 */
 class Google_AuthHandler_Guzzle6AuthHandler
 {

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1125,29 +1125,29 @@ class Google_Client
   protected function createDefaultHttpClient()
   {
       $guzzleVersion = null;
-      if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
-          $guzzleVersion = ClientInterface::MAJOR_VERSION;
-      } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-          $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
-      }
+    if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+      $guzzleVersion = ClientInterface::MAJOR_VERSION;
+    } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+      $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
+    }
 
       $options = ['exceptions' => false];
-      if (5 === $guzzleVersion) {
-          $options = [
-              'base_url' => $this->config['base_path'],
-              'defaults' => $options,
-          ];
-          if ($this->isAppEngine()) {
-              // set StreamHandler on AppEngine by default
-              $options['handler'] = new StreamHandler();
-              $options['defaults']['verify'] = '/etc/ca-certificates.crt';
-          }
-      } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
-          // guzzle 6 or 7
-          $options['base_uri'] = $this->config['base_path'];
-      } else {
-          throw new LogicException('Could not find support version of Guzzle.');
+    if (5 === $guzzleVersion) {
+      $options = [
+          'base_url' => $this->config['base_path'],
+          'defaults' => $options,
+      ];
+      if ($this->isAppEngine()) {
+          // set StreamHandler on AppEngine by default
+          $options['handler'] = new StreamHandler();
+          $options['defaults']['verify'] = '/etc/ca-certificates.crt';
       }
+    } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
+      // guzzle 6 or 7
+      $options['base_uri'] = $this->config['base_path'];
+    } else {
+      throw new LogicException('Could not find support version of Guzzle.');
+    }
 
       return new Client($options);
   }

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1146,7 +1146,7 @@ class Google_Client
       // guzzle 6 or 7
       $options['base_uri'] = $this->config['base_path'];
     } else {
-      throw new LogicException('Could not find support version of Guzzle.');
+      throw new LogicException('Could not find supported version of Guzzle.');
     }
 
     return new Client($options);

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1131,16 +1131,16 @@ class Google_Client
       $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
     }
 
-      $options = ['exceptions' => false];
+    $options = ['exceptions' => false];
     if (5 === $guzzleVersion) {
       $options = [
-          'base_url' => $this->config['base_path'],
-          'defaults' => $options,
+        'base_url' => $this->config['base_path'],
+        'defaults' => $options,
       ];
       if ($this->isAppEngine()) {
-          // set StreamHandler on AppEngine by default
-          $options['handler'] = new StreamHandler();
-          $options['defaults']['verify'] = '/etc/ca-certificates.crt';
+        // set StreamHandler on AppEngine by default
+        $options['handler'] = new StreamHandler();
+        $options['defaults']['verify'] = '/etc/ca-certificates.crt';
       }
     } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
       // guzzle 6 or 7
@@ -1149,7 +1149,7 @@ class Google_Client
       throw new LogicException('Could not find support version of Guzzle.');
     }
 
-      return new Client($options);
+    return new Client($options);
   }
 
   private function createApplicationDefaultCredentials()

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1124,25 +1124,32 @@ class Google_Client
 
   protected function createDefaultHttpClient()
   {
-    $options = ['exceptions' => false];
-
-    $version = ClientInterface::VERSION;
-    if ('5' === $version[0]) {
-      $options = [
-        'base_url' => $this->config['base_path'],
-        'defaults' => $options,
-      ];
-      if ($this->isAppEngine()) {
-        // set StreamHandler on AppEngine by default
-        $options['handler']  = new StreamHandler();
-        $options['defaults']['verify'] = '/etc/ca-certificates.crt';
+      $guzzleVersion = null;
+      if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+          $guzzleVersion = ClientInterface::MAJOR_VERSION;
+      } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+          $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
       }
-    } else {
-      // guzzle 6
-      $options['base_uri'] = $this->config['base_path'];
-    }
 
-    return new Client($options);
+      $options = ['exceptions' => false];
+      if (5 === $guzzleVersion) {
+          $options = [
+              'base_url' => $this->config['base_path'],
+              'defaults' => $options,
+          ];
+          if ($this->isAppEngine()) {
+              // set StreamHandler on AppEngine by default
+              $options['handler'] = new StreamHandler();
+              $options['defaults']['verify'] = '/etc/ca-certificates.crt';
+          }
+      } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
+          // guzzle 6 or 7
+          $options['base_uri'] = $this->config['base_path'];
+      } else {
+          throw new LogicException('Could not find support version of Guzzle.');
+      }
+
+      return new Client($options);
   }
 
   private function createApplicationDefaultCredentials()

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1124,7 +1124,7 @@ class Google_Client
 
   protected function createDefaultHttpClient()
   {
-      $guzzleVersion = null;
+    $guzzleVersion = null;
     if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
       $guzzleVersion = ClientInterface::MAJOR_VERSION;
     } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -59,7 +59,7 @@ class BaseTest extends TestCase
     }
 
     // adjust constructor depending on guzzle version
-    if (!$this->isGuzzle6()) {
+    if ($this->isGuzzle5()) {
       $options = ['defaults' => $options];
     }
 
@@ -208,8 +208,20 @@ class BaseTest extends TestCase
     return false;
   }
 
+  protected function isGuzzle7()
+  {
+    if (!defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
+      return false;
+    }
+
+    return (7 === ClientInterface::MAJOR_VERSION);
+  }
+
   protected function isGuzzle6()
   {
+    if (!defined('\GuzzleHttp\ClientInterface::VERSION')) {
+      return false;
+    }
     $version = ClientInterface::VERSION;
 
     return ('6' === $version[0]);
@@ -217,6 +229,10 @@ class BaseTest extends TestCase
 
   protected function isGuzzle5()
   {
+    if (!defined('\GuzzleHttp\ClientInterface::VERSION')) {
+      return false;
+    }
+
     $version = ClientInterface::VERSION;
 
     return ('5' === $version[0]);

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -44,7 +44,7 @@ class Google_ClientTest extends BaseTest
 
   private function checkAuthHandler($http, $className)
   {
-    if ($this->isGuzzle6()) {
+    if ($this->isGuzzle6() || $this->isGuzzle7()) {
       $stack = $http->getConfig('handler');
       $class = new ReflectionClass(get_class($stack));
       $property = $class->getProperty('stack');
@@ -75,7 +75,7 @@ class Google_ClientTest extends BaseTest
 
   private function checkCredentials($http, $fetcherClass, $sub = null)
   {
-    if ($this->isGuzzle6()) {
+    if ($this->isGuzzle6() || $this->isGuzzle7()) {
       $stack = $http->getConfig('handler');
       $class = new ReflectionClass(get_class($stack));
       $property = $class->getProperty('stack');


### PR DESCRIPTION
I did a quick search and found a few places where I could fix stuff. 
I have not found any other incompatibility issues, but this is not manually tested. 

The upgrade from Guzzle 6 to 7 is really smooth. See [upgrade docs](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md). But the upgrade to a future Guzzle 8 will not be. 

I strongly recommend to move towards PSR-18. Guzzle 7 support PSR-18 out of the box. 

Note: #1861

Blocked by https://github.com/googleapis/google-auth-library-php/pull/256