### PR TITLE
Add missing export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
-/CODE_OF_CONDUCT.md
+/CODE_OF_CONDUCT.md export-ignore
 /docs export-ignore
 /examples export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
During my previous PR https://github.com/googleapis/google-api-php-client/pull/1848 this line has been overlooked.