### PR TITLE
chore: fix deprecated syntax

### DIFF
--- a/src/Google/Http/REST.php
+++ b/src/Google/Http/REST.php
@@ -170,7 +170,7 @@ class Google_Http_REST
     }
 
     if (count($queryVars)) {
-      $requestUrl .= '?' . implode($queryVars, '&');
+      $requestUrl .= '?' . implode('&', $queryVars);
     }
 
     return $requestUrl;

--- a/src/Google/Utils.php
+++ b/src/Google/Utils.php
@@ -62,7 +62,7 @@ class Google_Utils
     $strlenVar = strlen($str);
     $d = $ret = 0;
     for ($count = 0; $count < $strlenVar; ++ $count) {
-      $ordinalValue = ord($str{$ret});
+      $ordinalValue = ord($str[$ret]);
       switch (true) {
         case (($ordinalValue >= 0x20) && ($ordinalValue <= 0x7F)):
           // characters U-00000000 - U-0000007F (same as ASCII)


### PR DESCRIPTION
Remove depreciation warnings for php 7.4 which cause some unit tests to fail