### PR TITLE
docs: fix invalid parameter type-hint for nextChunk

### DIFF
--- a/src/Google/Http/MediaFileUpload.php
+++ b/src/Google/Http/MediaFileUpload.php
@@ -114,7 +114,7 @@ class Google_Http_MediaFileUpload
 
   /**
    * Send the next part of the file to upload.
-   * @param bool $chunk Optional. The next set of bytes to send. If false will
+   * @param string|bool $chunk Optional. The next set of bytes to send. If false will
    * use $data passed at construct time.
    */
   public function nextChunk($chunk = false)


### PR DESCRIPTION
Pull request https://github.com/googleapis/google-api-php-client/pull/1872 adds some parameter type hints to code

For parameter `$chunk` in  `MediaFileUpload::nextChunk` it specifies a `bool` type but `string` should be also accepted because the implementation treats this parameter as it a string is.