### PR TITLE
Add content-type configurability in Resource->call method

### DIFF
--- a/src/Google/Service/Resource.php
+++ b/src/Google/Service/Resource.php
@@ -77,7 +77,7 @@ class Google_Service_Resource
    * @return Google_Http_Request|expectedClass
    * @throws Google_Exception
    */
-  public function call($name, $arguments, $expectedClass = null)
+  public function call($name, $arguments, $expectedClass = null, $contentType = 'application/json')
   {
     if (! isset($this->methods[$name])) {
       $this->client->getLogger()->error(
@@ -197,7 +197,7 @@ class Google_Service_Resource
     $request = new Request(
         $method['httpMethod'],
         $url,
-        ['content-type' => 'application/json'],
+        ['content-type' => $contentType],
         $postBody ? json_encode($postBody) : ''
     );
 


### PR DESCRIPTION
Some methods, for example `Google_Service_Doubleclicksearch_Resource_Reports.getFile` does not accept `application/json` as content-type of the request.

With this PR, each services could change the accepted content-type.