### PR TITLE
feat: add caching for GCE and access tokens by default

### DIFF
--- a/src/AuthHandler/Guzzle5AuthHandler.php
+++ b/src/AuthHandler/Guzzle5AuthHandler.php
@@ -39,6 +39,15 @@ class Guzzle5AuthHandler
           $this->cache
       );
     }
+
+    return $this->attachCredentialsCache($http, $credentials, $tokenCallback);
+  }
+
+  public function attachCredentialsCache(
+      ClientInterface $http,
+      FetchAuthTokenCache $credentials,
+      callable $tokenCallback = null
+  ) {
     // if we end up needing to make an HTTP request to retrieve credentials, we
     // can use our existing one, but we need to throw exceptions so the error
     // bubbles up.

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -39,6 +39,15 @@ class Guzzle6AuthHandler
           $this->cache
       );
     }
+
+    return $this->attachCredentialsCache($http, $credentials, $tokenCallback);
+  }
+
+  public function attachCredentialsCache(
+      ClientInterface $http,
+      FetchAuthTokenCache $credentials,
+      callable $tokenCallback = null
+  ) {
     // if we end up needing to make an HTTP request to retrieve credentials, we
     // can use our existing one, but we need to throw exceptions so the error
     // bubbles up.

--- a/src/Client.php
+++ b/src/Client.php
@@ -287,8 +287,9 @@ class Client
         'OAuth2 access token refresh with Signed JWT assertion grants.'
     );
 
-    $httpHandler = HttpHandlerFactory::build($authHttp);
     $credentials = $this->createApplicationDefaultCredentials();
+
+    $httpHandler = HttpHandlerFactory::build($authHttp);
     $creds = $credentials->fetchAuthToken($httpHandler);
     if ($creds && isset($creds['access_token'])) {
       $creds['created'] = time();

--- a/src/Client.php
+++ b/src/Client.php
@@ -1218,7 +1218,11 @@ class Client
       $credentials->setSub($sub);
     }
 
-    return $credentials;
+    return new FetchAuthTokenCache(
+      $creds,
+      $this->config['cache_config'],
+      $this->getCache()
+    );
   }
 
   protected function getAuthHandler()

--- a/src/Client.php
+++ b/src/Client.php
@@ -441,6 +441,8 @@ class Client
     } elseif ($key = $this->config['developer_key']) {
       $http = $authHandler->attachKey($http, $key);
     }
+
+    return $http;
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -279,8 +279,9 @@ class Client
         'OAuth2 access token refresh with Signed JWT assertion grants.'
     );
 
-    $httpHandler = HttpHandlerFactory::build($authHttp);
     $credentials = $this->createApplicationDefaultCredentials();
+
+    $httpHandler = HttpHandlerFactory::build($authHttp);
     $creds = $credentials->fetchAuthToken($httpHandler);
     if ($creds && isset($creds['access_token'])) {
       $creds['created'] = time();

--- a/src/Client.php
+++ b/src/Client.php
@@ -287,9 +287,8 @@ class Client
         'OAuth2 access token refresh with Signed JWT assertion grants.'
     );
 
-    $credentials = $this->createApplicationDefaultCredentials();
-
     $httpHandler = HttpHandlerFactory::build($authHttp);
+    $credentials = $this->createApplicationDefaultCredentials();
     $creds = $credentials->fetchAuthToken($httpHandler);
     if ($creds && isset($creds['access_token'])) {
       $creds['created'] = time();
@@ -442,8 +441,6 @@ class Client
     } elseif ($key = $this->config['developer_key']) {
       $http = $authHandler->attachKey($http, $key);
     }
-
-    return $http;
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -433,6 +433,8 @@ class Client
     } elseif ($key = $this->config['developer_key']) {
       $http = $authHandler->attachKey($http, $key);
     }
+
+    return $http;
   }
 
   /**
@@ -1179,6 +1181,9 @@ class Client
     return new GuzzleClient($options);
   }
 
+  /**
+   * @return FetchAuthTokenCache
+   */
   private function createApplicationDefaultCredentials()
   {
     $scopes = $this->prepareScopes();

--- a/src/Client.php
+++ b/src/Client.php
@@ -153,6 +153,9 @@ class Client
           'retry' => array(),
           'retry_map' => null,
 
+          // Cache class implementing Psr\Cache\CacheItemPoolInterface.
+          // Defaults to Google\Auth\Cache\MemoryCacheItemPool.
+          'cache' => null,
           // cache config for downstream auth caching
           'cache_config' => [],
 
@@ -192,6 +195,11 @@ class Client
             ]
         );
       };
+    }
+
+    if (!is_null($this->config['cache'])) {
+      $this->setCache($this->config['cache']);
+      unset($this->config['cache']);
     }
   }
 

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -828,41 +828,6 @@ class Google_ClientTest extends BaseTest
     $this->assertEquals($mockCache->reveal(), $client->getCache());
   }
 
-  /** @runInSeparateProcess */
-  public function testFetchAccessTokenWithAssertionCache()
-  {
-    $this->checkServiceAccountCredentials();
-    $cachedValue = ['access_token' => '2/abcdef1234567890'];
-    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
-    $mockCacheItem->isHit()
-        ->shouldBeCalledTimes(1)
-        ->willReturn(true);
-    $mockCacheItem->get()
-        ->shouldBeCalledTimes(1)
-        ->willReturn($cachedValue);
-
-    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
-    $mockCache->getItem(Argument::any())
-        ->shouldBeCalledTimes(1)
-        ->willReturn($mockCacheItem->reveal());
-
-    $client = new Google_Client();
-    $client->setCache($mockCache->reveal());
-    $client->useApplicationDefaultCredentials();
-    $token = $client->fetchAccessTokenWithAssertion();
-    $this->assertArrayHasKey('access_token', $token);
-    $this->assertEquals($cachedValue['access_token'], $token['access_token']);
-  }
-
-  public function testCacheClientOption()
-  {
-    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
-    $client = new Google_Client([
-      'cache' => $mockCache->reveal()
-    ]);
-    $this->assertEquals($mockCache->reveal(), $client->getCache());
-  }
-
   public function testExecuteWithFormat()
   {
     $this->onlyGuzzle6Or7();

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -829,36 +829,6 @@ class Google_ClientTest extends BaseTest
   }
 
   /** @runInSeparateProcess */
-  public function testOnGceCacheAndCacheOptions()
-  {
-    if (!class_exists('Google\Auth\GCECache')) {
-      $this->markTestSkipped('Requires google/auth >= 1.12');
-    }
-
-    putenv('HOME=');
-    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
-    $prefix = 'test_prefix_';
-    $cacheConfig = ['gce_prefix' => $prefix];
-
-    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
-    $mockCacheItem->isHit()
-        ->willReturn(true);
-    $mockCacheItem->get()
-        ->shouldBeCalledTimes(1)
-        ->willReturn(true);
-
-    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
-    $mockCache->getItem($prefix . Google\Auth\GCECache::GCE_CACHE_KEY)
-        ->shouldBeCalledTimes(1)
-        ->willReturn($mockCacheItem->reveal());
-
-    $client = new Google_Client(['cache_config' => $cacheConfig]);
-    $client->setCache($mockCache->reveal());
-    $client->useApplicationDefaultCredentials();
-    $client->authorize();
-  }
-
-  /** @runInSeparateProcess */
   public function testFetchAccessTokenWithAssertionCache()
   {
     $this->checkServiceAccountCredentials();

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -836,6 +836,7 @@ class Google_ClientTest extends BaseTest
     }
 
     putenv('HOME=');
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
     $prefix = 'test_prefix_';
     $cacheConfig = ['gce_prefix' => $prefix];
 
@@ -857,8 +858,10 @@ class Google_ClientTest extends BaseTest
     $client->authorize();
   }
 
+  /** @runInSeparateProcess */
   public function testFetchAccessTokenWithAssertionCache()
   {
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
     $cachedValue = ['access_token' => '2/abcdef1234567890'];
     $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
     $mockCacheItem->isHit()

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -771,6 +771,7 @@ class Google_ClientTest extends BaseTest
     }
 
     putenv('HOME=');
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
     $prefix = 'test_prefix_';
     $cacheConfig = ['gce_prefix' => $prefix];
 
@@ -792,8 +793,10 @@ class Google_ClientTest extends BaseTest
     $client->authorize();
   }
 
+  /** @runInSeparateProcess */
   public function testFetchAccessTokenWithAssertionCache()
   {
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
     $cachedValue = ['access_token' => '2/abcdef1234567890'];
     $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
     $mockCacheItem->isHit()

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -861,7 +861,7 @@ class Google_ClientTest extends BaseTest
   /** @runInSeparateProcess */
   public function testFetchAccessTokenWithAssertionCache()
   {
-    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
+    $this->checkServiceAccountCredentials();
     $cachedValue = ['access_token' => '2/abcdef1234567890'];
     $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
     $mockCacheItem->isHit()

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -763,6 +763,68 @@ class Google_ClientTest extends BaseTest
     $this->assertFalse($client->isAccessTokenExpired());
   }
 
+  /** @runInSeparateProcess */
+  public function testOnGceCacheAndCacheOptions()
+  {
+    if (!class_exists('Google\Auth\GCECache')) {
+      $this->markTestSkipped('Requires google/auth >= 1.12');
+    }
+
+    putenv('HOME=');
+    $prefix = 'test_prefix_';
+    $cacheConfig = ['gce_prefix' => $prefix];
+
+    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+    $mockCacheItem->isHit()
+        ->willReturn(true);
+    $mockCacheItem->get()
+        ->shouldBeCalledTimes(1)
+        ->willReturn(true);
+
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $mockCache->getItem($prefix . Google\Auth\GCECache::GCE_CACHE_KEY)
+        ->shouldBeCalledTimes(1)
+        ->willReturn($mockCacheItem->reveal());
+
+    $client = new Google_Client(['cache_config' => $cacheConfig]);
+    $client->setCache($mockCache->reveal());
+    $client->useApplicationDefaultCredentials();
+    $client->authorize();
+  }
+
+  public function testFetchAccessTokenWithAssertionCache()
+  {
+    $cachedValue = ['access_token' => '2/abcdef1234567890'];
+    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+    $mockCacheItem->isHit()
+        ->shouldBeCalledTimes(1)
+        ->willReturn(true);
+    $mockCacheItem->get()
+        ->shouldBeCalledTimes(1)
+        ->willReturn($cachedValue);
+
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $mockCache->getItem(Argument::any())
+        ->shouldBeCalledTimes(1)
+        ->willReturn($mockCacheItem->reveal());
+
+    $client = new Google_Client();
+    $client->setCache($mockCache->reveal());
+    $client->useApplicationDefaultCredentials();
+    $token = $client->fetchAccessTokenWithAssertion();
+    $this->assertArrayHasKey('access_token', $token);
+    $this->assertEquals($cachedValue['access_token'], $token['access_token']);
+  }
+
+  public function testCacheClientOption()
+  {
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $client = new Google_Client([
+      'cache' => $mockCache->reveal()
+    ]);
+    $this->assertEquals($mockCache->reveal(), $client->getCache());
+  }
+
   public function testExecuteWithFormat()
   {
     $this->onlyGuzzle6Or7();

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -796,7 +796,7 @@ class Google_ClientTest extends BaseTest
   /** @runInSeparateProcess */
   public function testFetchAccessTokenWithAssertionCache()
   {
-    putenv('GOOGLE_APPLICATION_CREDENTIALS=');
+    $this->checkServiceAccountCredentials();
     $cachedValue = ['access_token' => '2/abcdef1234567890'];
     $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
     $mockCacheItem->isHit()

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -828,6 +828,68 @@ class Google_ClientTest extends BaseTest
     $this->assertEquals($mockCache->reveal(), $client->getCache());
   }
 
+  /** @runInSeparateProcess */
+  public function testOnGceCacheAndCacheOptions()
+  {
+    if (!class_exists('Google\Auth\GCECache')) {
+      $this->markTestSkipped('Requires google/auth >= 1.12');
+    }
+
+    putenv('HOME=');
+    $prefix = 'test_prefix_';
+    $cacheConfig = ['gce_prefix' => $prefix];
+
+    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+    $mockCacheItem->isHit()
+        ->willReturn(true);
+    $mockCacheItem->get()
+        ->shouldBeCalledTimes(1)
+        ->willReturn(true);
+
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $mockCache->getItem($prefix . Google\Auth\GCECache::GCE_CACHE_KEY)
+        ->shouldBeCalledTimes(1)
+        ->willReturn($mockCacheItem->reveal());
+
+    $client = new Google_Client(['cache_config' => $cacheConfig]);
+    $client->setCache($mockCache->reveal());
+    $client->useApplicationDefaultCredentials();
+    $client->authorize();
+  }
+
+  public function testFetchAccessTokenWithAssertionCache()
+  {
+    $cachedValue = ['access_token' => '2/abcdef1234567890'];
+    $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+    $mockCacheItem->isHit()
+        ->shouldBeCalledTimes(1)
+        ->willReturn(true);
+    $mockCacheItem->get()
+        ->shouldBeCalledTimes(1)
+        ->willReturn($cachedValue);
+
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $mockCache->getItem(Argument::any())
+        ->shouldBeCalledTimes(1)
+        ->willReturn($mockCacheItem->reveal());
+
+    $client = new Google_Client();
+    $client->setCache($mockCache->reveal());
+    $client->useApplicationDefaultCredentials();
+    $token = $client->fetchAccessTokenWithAssertion();
+    $this->assertArrayHasKey('access_token', $token);
+    $this->assertEquals($cachedValue['access_token'], $token['access_token']);
+  }
+
+  public function testCacheClientOption()
+  {
+    $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+    $client = new Google_Client([
+      'cache' => $mockCache->reveal()
+    ]);
+    $this->assertEquals($mockCache->reveal(), $client->getCache());
+  }
+
   public function testExecuteWithFormat()
   {
     $this->onlyGuzzle6Or7();


### PR DESCRIPTION
 - Passes cache to calls to `ApplicationDefaultCredentials::getCredentials` to take advantage of new onGce cache
 - Wraps credentials in `FetchAuthTokenCache` on calls to `ApplicationDefaultCredentials::fetchAccessTokenWithAssertion`