### PR TITLE
Issue 1965 - Exceptions option fallback to http_errors on guzzle 6 or 7

### DIFF
--- a/src/Google/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/Google/AuthHandler/Guzzle6AuthHandler.php
@@ -97,7 +97,7 @@ class Google_AuthHandler_Guzzle6AuthHandler
     return new Client(
         [
           'base_uri' => $http->getConfig('base_uri'),
-          'exceptions' => true,
+          'http_errors' => true,
           'verify' => $http->getConfig('verify'),
           'proxy' => $http->getConfig('proxy'),
         ]

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1162,6 +1162,9 @@ class Google_Client
     } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
       // guzzle 6 or 7
       $options['base_uri'] = $this->config['base_path'];
+
+      $options['http_errors'] = $options['exceptions'];
+      unset($options['exceptions']);
     } else {
       throw new LogicException('Could not find supported version of Guzzle.');
     }

--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -1148,11 +1148,10 @@ class Google_Client
       $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
     }
 
-    $options = ['exceptions' => false];
     if (5 === $guzzleVersion) {
       $options = [
         'base_url' => $this->config['base_path'],
-        'defaults' => $options,
+        'defaults' => ['exceptions' => false],
       ];
       if ($this->isAppEngine()) {
         // set StreamHandler on AppEngine by default
@@ -1161,10 +1160,10 @@ class Google_Client
       }
     } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
       // guzzle 6 or 7
-      $options['base_uri'] = $this->config['base_path'];
-
-      $options['http_errors'] = $options['exceptions'];
-      unset($options['exceptions']);
+      $options = [
+        'base_uri' => $this->config['base_path'],
+        'http_errors' => false,
+      ];
     } else {
       throw new LogicException('Could not find supported version of Guzzle.');
     }

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -310,9 +310,9 @@ class Google_ClientTest extends BaseTest
           $this->assertFalse($client->getHttpClient()->getConfig()['http_errors']);
       }
       if ($this->isGuzzle5()) {
-          $this->assertArrayHasKey('exceptions', $client->getHttpClient()->getConfig());
-          $this->assertArrayNotHasKey('http_errors', $client->getHttpClient()->getConfig());
-          $this->assertFalse($client->getHttpClient()->getConfig()['exceptions']);
+          $this->assertArrayHasKey('exceptions', $client->getHttpClient()->getDefaultOption());
+          $this->assertArrayNotHasKey('http_errors', $client->getHttpClient()->getDefaultOption());
+          $this->assertFalse($client->getHttpClient()->getDefaultOption()['exceptions']);
       }
   }
 

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -301,6 +301,21 @@ class Google_ClientTest extends BaseTest
     $this->assertEquals($token, $client->getAccessToken());
   }
 
+  public function testDefaultConfigOptions()
+  {
+      $client = new Google_Client();
+      if ($this->isGuzzle6() || $this->isGuzzle7()) {
+          $this->assertArrayHasKey('http_errors', $client->getHttpClient()->getConfig());
+          $this->assertArrayNotHasKey('exceptions', $client->getHttpClient()->getConfig());
+          $this->assertFalse($client->getHttpClient()->getConfig()['http_errors']);
+      }
+      if ($this->isGuzzle5()) {
+          $this->assertArrayHasKey('exceptions', $client->getHttpClient()->getConfig());
+          $this->assertArrayNotHasKey('http_errors', $client->getHttpClient()->getConfig());
+          $this->assertFalse($client->getHttpClient()->getConfig()['exceptions']);
+      }
+  }
+
   public function testAppEngineStreamHandlerConfig()
   {
     $this->onlyGuzzle5();


### PR DESCRIPTION
## Misc

Fix for #1964 

## Changes

### Updates

- default options `exceptions` changed to `http_errors` when guzzle version is 6 or 7. (The deprecation of `exceptions` was implemented in guzzle 6 and enforced in guzzle 7).

