### PR TITLE
Do not use autoload when check class existence.

### DIFF
--- a/src/aliases.php
+++ b/src/aliases.php
@@ -1,6 +1,6 @@
 <?php
 
-if (class_exists('Google_Client')) {
+if (class_exists('Google_Client', false)) {
     // Prevent error with preloading in PHP 7.4
     // @see https://github.com/googleapis/google-api-php-client/issues/1976
     return;


### PR DESCRIPTION
Do not use autoload functionality when check class existence.
With default "true" it will fail on custom autoload.