### PR TITLE
fix: exclude PageSpeed Insights API errors from retries.

### DIFF
--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -81,7 +81,7 @@ class Runner
     7  => self::TASK_RETRY_ALWAYS,  // CURLE_COULDNT_CONNECT
     28 => self::TASK_RETRY_ALWAYS,  // CURLE_OPERATION_TIMEOUTED
     35 => self::TASK_RETRY_ALWAYS,  // CURLE_SSL_CONNECT_ERROR
-    52 => self::TASK_RETRY_ALWAYS,   // CURLE_GOT_NOTHING
+    52 => self::TASK_RETRY_ALWAYS,  // CURLE_GOT_NOTHING
     'lighthouseError' => self::TASK_RETRY_NEVER
   ];
 

--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -81,7 +81,8 @@ class Runner
     7  => self::TASK_RETRY_ALWAYS,  // CURLE_COULDNT_CONNECT
     28 => self::TASK_RETRY_ALWAYS,  // CURLE_OPERATION_TIMEOUTED
     35 => self::TASK_RETRY_ALWAYS,  // CURLE_SSL_CONNECT_ERROR
-    52 => self::TASK_RETRY_ALWAYS   // CURLE_GOT_NOTHING
+    52 => self::TASK_RETRY_ALWAYS,   // CURLE_GOT_NOTHING
+    'lighthouseError' => self::TASK_RETRY_NEVER 
   ];
 
   /**

--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -82,7 +82,7 @@ class Runner
     28 => self::TASK_RETRY_ALWAYS,  // CURLE_OPERATION_TIMEOUTED
     35 => self::TASK_RETRY_ALWAYS,  // CURLE_SSL_CONNECT_ERROR
     52 => self::TASK_RETRY_ALWAYS,   // CURLE_GOT_NOTHING
-    'lighthouseError' => self::TASK_RETRY_NEVER 
+    'lighthouseError' => self::TASK_RETRY_NEVER
   ];
 
   /**


### PR DESCRIPTION
When retries are enabled in the client, the Runner class [by default](https://github.com/googleapis/google-api-php-client/blob/81696e6206322e38c643cfcc96c4494ccfef8a32/src/Task/Runner.php#L76) retries requests when the API returns a `500` error code. Unfortunately, the PageSpeed Insights [API](https://developers.google.com/speed/pagespeed/insights/) returns 5XX's for errors that should really be 4XX (specifically in Lighthouse for the errors ERRORED_DOCUMENT_REQUEST, FAILED_DOCUMENT_REQUEST). So 500 errors from this API shouldn't be retried, they will only increase load and fail again. 

These errors are non-retryable user defined errors: for example requesting data for a url that doesn't go anywhere. This PR changes the default client behavior to avoid retrying requests the the reason `lighthouseError`, preventing unnecessary retries. 

### Steps to reproduce
1. Visit the PageSpeed Insights [API explorer page](https://developers.google.com/speed/docs/insights/v5/reference/pagespeedapi/runpagespeed)
2. Enter a domain that does non exist in the URL field, for example `https://notareal-websiteno.com`, and run the report.
2. Note the returned error response is a 500 error.

![image](https://user-images.githubusercontent.com/2676022/101094827-3ec03c00-357a-11eb-859d-8885630975be.png)

### Additional Context
We recently [added this change](https://github.com/google/site-kit-wp/blob/42ec0aaa2a9b1861a8ad0288ebf7b3d86448617a/includes/Core/Authentication/Clients/OAuth_Client.php#L181) the the defaults used by [Site Kit](https://sitekit.withgoogle.com/) which relies on this library. Since we found this condition important enough to explicitly exclude, I thought it might be worth contributing upstream, although I'm not sure you want to add these types of API specific exceptions.
