### PR TITLE
fix: ensure names match sync repo settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
                 composer-flags: [""]
                 include:
                   - php: "5.6"
-                    composer-flags: "--prefer-lowest"
+                    composer-flags: "--prefer-lowest "
                   - php: "8.0"
-                    composer-flags: "--prefer-lowest"
-        name: PHP ${{ matrix.php }} ${{ matrix.composer-flags }} Unit Test
+                    composer-flags: "--prefer-lowest "
+        name: PHP ${{ matrix.php }} ${{ matrix.composer-flags }}Unit Test
         steps:
             - uses: actions/checkout@v2
             - name: Setup PHP


### PR DESCRIPTION
There was an extra space (easy to miss) which was making the names different in the sync repo settings file