### PR TITLE
chore: prepare v2.9.0

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -49,7 +49,7 @@ use LogicException;
  */
 class Client
 {
-  const LIBVER = "2.8.3";
+  const LIBVER = "2.9.0";
   const USER_AGENT_SUFFIX = "google-api-php-client/";
   const OAUTH2_REVOKE_URI = 'https://oauth2.googleapis.com/revoke';
   const OAUTH2_TOKEN_URI = 'https://oauth2.googleapis.com/token';


### PR DESCRIPTION
## PHP Version Requirements

:heavy_exclamation_mark: Note that PHP versions 5.4 and 5.5 and phpseclib lower than version 2.0 are no longer supported.

## Features

* support phpseclib version 3 (#2019)
* add support for php 8 (#2017)

## Bug fixes

* ensure names match sync repo settings (#2022)
* exclude PageSpeed Insights API errors from retries. (#2010)

---

I'm assuming we'll merge #2010 before releasing this. @bshaffer can you confirm? 