### PR TITLE
fix: ensure composer cleanup works for upcoming service namespaces

### DIFF
--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -37,10 +37,18 @@ class Composer
     $servicesToKeep = isset($extra['google/apiclient-services']) ?
       $extra['google/apiclient-services'] : [];
     if ($servicesToKeep) {
+      $vendorDir = $composer->getConfig()->get('vendor-dir');
       $serviceDir = sprintf(
           '%s/google/apiclient-services/src/Google/Service',
-          $composer->getConfig()->get('vendor-dir')
+          $vendorDir
       );
+      if (!is_dir($serviceDir)) {
+        // path for google/apiclient-services >= 0.200.0
+        $serviceDir = sprintf(
+            '%s/google/apiclient-services/src',
+            $vendorDir
+        );
+      }
       self::verifyServicesToKeep($serviceDir, $servicesToKeep);
       $finder = self::getServicesToRemove($serviceDir, $servicesToKeep);
       $filesystem = $filesystem ?: new Filesystem();


### PR DESCRIPTION
See https://github.com/googleapis/google-api-php-client-services/pull/363