### PR TITLE
Change google/apiclient-services requirement from ^0.200.0 to ~0.200

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.6|^7.0|^8.0",
         "google/auth": "^1.10",
-        "google/apiclient-services": "^0.200.0",
+        "google/apiclient-services": "~0.200.0",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~2.0||^3.0.2",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.6|^7.0|^8.0",
         "google/auth": "^1.10",
-        "google/apiclient-services": "~0.200.0",
+        "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~2.0||^3.0.2",


### PR DESCRIPTION
Fixes #2092

[From the Composer documentation](https://getcomposer.org/doc/articles/versions.md#next-significant-release-operators):
> The ^ operator behaves very similarly, but it sticks closer to semantic versioning, and will always allow non-breaking updates. For example ^1.2.3 is equivalent to >=1.2.3 <2.0.0 as none of the releases until 2.0 should break backwards compatibility. For pre-1.0 versions it also acts with safety in mind and treats ^0.3 as >=0.3.0 <0.4.0.

The important part being the last sentence.