### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~2.0||^3.0.2",
         "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",
+        "symfony/polyfill-php81": "^1.23.0",
         "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -54,6 +54,7 @@ class Collection extends Model implements \Iterator, \Countable
     return count($this->{$this->collection_key});
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     if (!is_numeric($offset)) {
@@ -62,6 +63,7 @@ class Collection extends Model implements \Iterator, \Countable
     return isset($this->{$this->collection_key}[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     if (!is_numeric($offset)) {
@@ -71,6 +73,7 @@ class Collection extends Model implements \Iterator, \Countable
     return $this->{$this->collection_key}[$offset];
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     if (!is_numeric($offset)) {
@@ -79,6 +82,7 @@ class Collection extends Model implements \Iterator, \Countable
     $this->{$this->collection_key}[$offset] = $value;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     if (!is_numeric($offset)) {

--- a/src/Model.php
+++ b/src/Model.php
@@ -253,11 +253,13 @@ class Model implements \ArrayAccess
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset)
   {
     return isset($this->$offset) || isset($this->modelData[$offset]);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset)
   {
     return isset($this->$offset) ?
@@ -265,6 +267,7 @@ class Model implements \ArrayAccess
         $this->__get($offset);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value)
   {
     if (property_exists($this, $offset)) {
@@ -275,6 +278,7 @@ class Model implements \ArrayAccess
     }
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset)
   {
     unset($this->modelData[$offset]);


### PR DESCRIPTION
Avoids deprecations messages as: 
```
PHP Deprecated:  Return type of Google\Model::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/pimcore/pimcore/vendor/google/apiclient/src/Model.php on line 256
```
