### PR TITLE
fix: ensure refresh token remains after get token callback

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -188,11 +188,14 @@ class Client
     if (is_null($this->config['token_callback'])) {
       $this->config['token_callback'] = function ($cacheKey, $newAccessToken) {
         $this->setAccessToken(
-            [
-              'access_token' => $newAccessToken,
-              'expires_in' => 3600, // Google default
-              'created' => time(),
-            ]
+            array_merge(
+                $this->getAccessToken(),
+                [
+                  'access_token' => $newAccessToken,
+                  'expires_in' => 3600, // Google default
+                  'created' => time(),
+                ]
+            )
         );
       };
     }

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -774,6 +774,12 @@ class ClientTest extends BaseTest
       $newToken['access_token']
     );
 
+    // Assert refresh token remains
+    $this->assertEquals(
+      $accessToken['refresh_token'],
+      $newToken['refresh_token']
+    );
+
     $this->assertFalse($client->isAccessTokenExpired());
   }
 


### PR DESCRIPTION
When a token expires and refresh token is provided, first time on "authorize" refresh the token. 

However, this dispatch the "token callback" to save the new token (and get the new expiration time) but it doesn't set again this refresh_token, so the token keeps without this data and on the next expiration, it will not refresh the token for this reason.

With this PR we ensure that the refresh token remains on the token property always.

EDIT: I've added merge old token configuration for scopes, grant type...