### PR TITLE
Allow Users to Set Additional Guzzle Options

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -169,7 +169,10 @@ class Client
 
           // Setting api_format_v2 will return more detailed error messages
           // from certain APIs.
-          'api_format_v2' => false
+          'api_format_v2' => false,
+          
+          // Setting additional guzzle options for the default http client
+          'guzzle_options' => [],
         ],
         $config
     );
@@ -1186,6 +1189,11 @@ class Client
     } else {
       throw new LogicException('Could not find supported version of Guzzle.');
     }
+
+    $options = array_merge(
+      $options,
+      $this->config['guzzle_options'],
+    );
 
     return new GuzzleClient($options);
   }


### PR DESCRIPTION
This PR will summarize the `$config`-based solution I'm thinking of for issue #2155, where we need to pass the `proxy` settings to the default HTTP client (i.e., the Guzzle client) because our server code doesn't have direct control of the `Google\Client` class (i.e., we can't create a custom HTTP client with the proper proxy settings and hand it over to `Google\Client` in our use case), and we can only interact with this client class via `$config` settings. 