### PR TITLE
Remove redundand and invalid "classmap" in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,6 @@
         },
         "files": [
             "src/aliases.php"
-        ],
-        "classmap": [
-            "src/aliases.php"
         ]
     },
     "extra": {


### PR DESCRIPTION
"src/aliases.php" is not classmap