### PR TITLE
Ensure the headers are combined

### DIFF
--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -207,7 +207,7 @@ EOF;
         list($header, $value) = explode(': ', $headerLine, 2);
         $header = strtolower($header);
         if (isset($headers[$header])) {
-          $headers[$header] .= "\n" . $value;
+          $headers[$header] .= ", " . $value;
         } else {
           $headers[$header] = $value;
         }


### PR DESCRIPTION
Add the headers together if the header already exists instead of splitting them with a new line

See #2230

More info on the Vary header can be found at:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary 

Have done a deep test myself but i thought it would be wise to raise an early PR for this