### PR TITLE
Fixed wrong header concatenation

### DIFF
--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -207,7 +207,7 @@ EOF;
         list($header, $value) = explode(': ', $headerLine, 2);
         $header = strtolower($header);
         if (isset($headers[$header])) {
-          $headers[$header] .= "\n" . $value;
+          $headers[$header] .= ", " . $value;
         } else {
           $headers[$header] = $value;
         }

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -207,7 +207,7 @@ EOF;
         list($header, $value) = explode(': ', $headerLine, 2);
         $header = strtolower($header);
         if (isset($headers[$header])) {
-          $headers[$header] .= ", " . $value;
+          $headers[$header] = array_merge((array)$headers[$header], (array)$value);
         } else {
           $headers[$header] = $value;
         }


### PR DESCRIPTION
The new version of PRS7 2.2.1 header validation is stricter this commit solves the header validation problem.

Current:
```
Vary: Origin\n
X-Origin\n
Referer\n
```

Should be:
```
Vary: Origin, X-Origin, Referer
```

https://github.com/guzzle/psr7

More information about concatenation of headers:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary

See https://github.com/googleapis/google-api-php-client/issues/2230