### PR TITLE
Bump firebase/php-jwt to patch Insecure Encryption CVE-2021-46743

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.6|^7.0|^8.0",
         "google/auth": "^1.10",
         "google/apiclient-services": "~0.200",
-        "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
+        "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0||~6.0",
         "monolog/monolog": "^1.17||^2.0",
         "phpseclib/phpseclib": "~2.0||^3.0.2",
         "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",


### PR DESCRIPTION
Fix [CVE-2021-46743](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46743)
Introduced through: firebase/php-jwt@5.5.1

Affected versions of this package are vulnerable to Insecure Encryption due to an algorithm-confusion issue (e.g., RS256 / HS256) that exists via the kid (aka Key ID) header when multiple types of keys are loaded in a key ring. This allows an attacker to forge tokens that validate under the incorrect key.