### PR TITLE
Verify.php import InvalidArgumentException

### DIFF
--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -28,8 +28,6 @@ use phpseclib3\Crypt\RSA\PublicKey;
 use Psr\Cache\CacheItemPoolInterface;
 use Google\Auth\Cache\MemoryCacheItemPool;
 use Google\Exception as GoogleException;
-use Stash\Driver\FileSystem;
-use Stash\Pool;
 use DateTime;
 use DomainException;
 use Exception;

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -22,6 +22,7 @@ use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
 use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
+use InvalidArgumentException;
 use phpseclib3\Crypt\PublicKeyLoader;
 use phpseclib3\Crypt\RSA\PublicKey;
 use Psr\Cache\CacheItemPoolInterface;


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-php-client/issues/2237
Additionally removed unused imports