### PR TITLE
Fix #2243

### DIFF
--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -19,6 +19,7 @@
 namespace Google\AccessToken;
 
 use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
+use Firebase\JWT\Key;
 use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
@@ -100,9 +101,8 @@ class Verify
     foreach ($certs as $cert) {
       try {
         $payload = $this->jwt->decode(
-            $idToken,
-            $this->getPublicKey($cert),
-            array('RS256')
+          $idToken,
+          new Key($this->getPublicKey($cert), 'RS256')
         );
 
         if (property_exists($payload, 'aud')) {


### PR DESCRIPTION
This PR is a follow up to issue #2243. It looks like, at the very least, v5 and v6 of firebase/php-jwt accept an instance of `Firebase\JWT\Key` as the 2nd argument to `JWT::decode()`. All of the tests pass but at least one of them should have been failing before this change if you have firebase/php-jwt v6 installed. 

I can add/update tests if required.