### PR TITLE
chore: remove tag trigger

### DIFF
--- a/.github/actions/docs/entrypoint.sh
+++ b/.github/actions/docs/entrypoint.sh
@@ -2,7 +2,6 @@
 
 apt-get update
 apt-get install -y git wget
-git checkout main
 git reset --hard HEAD
 
 # Create the directories

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Generate Documentation
 on:
     push:
-        branches:
-            - main
-        tags:
-            - "*"
+        branches: [main]
 
 jobs:
     docs:


### PR DESCRIPTION
For some reason, when `generate documentation` is triggered on a tagged release, the `main` branch isn't generated. I could not reproduce this locally, and looking at the code, I cannot find out what is causing this behavior. So rather than have our documentation be broken after every release, we'll just remove the tag trigger. This will mean the `main` docs will be up-to-date, but the tags will lag behind. It's not ideal, but it's better than having our default documentation be broken.