### PR TITLE
chore: misc code style fixes

### DIFF
--- a/examples/batch.php
+++ b/examples/batch.php
@@ -63,7 +63,7 @@ $client->setUseBatch(true);
 $batch = $service->createBatch();
 
 $query = 'Henry David Thoreau';
-$optParams = array('filter' => 'free-ebooks');
+$optParams = ['filter' => 'free-ebooks'];
 $req1 = $service->volumes->listVolumes($query, $optParams);
 $batch->add($req1, "thoreau");
 $query = 'George Bernard Shaw';

--- a/examples/multi-api.php
+++ b/examples/multi-api.php
@@ -88,13 +88,13 @@ $dr_service = new Google\Service\Drive($client);
 if ($client->getAccessToken()) {
     $_SESSION['multi-api-token'] = $client->getAccessToken();
 
-    $dr_results = $dr_service->files->listFiles(array('pageSize' => 10));
+    $dr_results = $dr_service->files->listFiles(['pageSize' => 10]);
 
-    $yt_channels = $yt_service->channels->listChannels('contentDetails', array("mine" => true));
+    $yt_channels = $yt_service->channels->listChannels('contentDetails', ["mine" => true]);
     $likePlaylist = $yt_channels[0]->contentDetails->relatedPlaylists->likes;
     $yt_results = $yt_service->playlistItems->listPlaylistItems(
         "snippet",
-        array("playlistId" => $likePlaylist)
+        ["playlistId" => $likePlaylist]
     );
 }
 ?>

--- a/examples/service-account.php
+++ b/examples/service-account.php
@@ -60,9 +60,9 @@ $service = new Google\Service\Books($client);
   simple query as an example.
  ************************************************/
 $query = 'Henry David Thoreau';
-$optParams = array(
+$optParams = [
     'filter' => 'free-ebooks',
-);
+];
 $results = $service->volumes->listVolumes($query, $optParams);
 ?>
 

--- a/examples/simple-file-upload.php
+++ b/examples/simple-file-upload.php
@@ -91,11 +91,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && $client->getAccessToken()) {
     $file = new Google\Service\Drive\DriveFile();
     $result = $service->files->create(
         $file,
-        array(
+        [
             'data' => file_get_contents(TESTFILE),
             'mimeType' => 'application/octet-stream',
             'uploadType' => 'media'
-        )
+        ]
     );
 
     // Now lets try and send the metadata as well using multipart!
@@ -103,11 +103,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && $client->getAccessToken()) {
     $file->setName("Hello World!");
     $result2 = $service->files->create(
         $file,
-        array(
+        [
             'data' => file_get_contents(TESTFILE),
             'mimeType' => 'application/octet-stream',
             'uploadType' => 'multipart'
-        )
+        ]
     );
 }
 ?>

--- a/examples/simple-query.php
+++ b/examples/simple-query.php
@@ -48,9 +48,9 @@ $service = new Google\Service\Books($client);
   parameters.
  ************************************************/
 $query = 'Henry David Thoreau';
-$optParams = array(
+$optParams = [
     'filter' => 'free-ebooks',
-);
+];
 $results = $service->volumes->listVolumes($query, $optParams);
 
  /************************************************
@@ -58,9 +58,9 @@ $results = $service->volumes->listVolumes($query, $optParams);
  ***********************************************/
 $client->setDefer(true);
 $query = 'Henry David Thoreau';
-$optParams = array(
+$optParams = [
     'filter' => 'free-ebooks',
-);
+];
 $request = $service->volumes->listVolumes($query, $optParams);
 $resultsDeferred = $client->execute($request);
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -64,6 +64,9 @@
   <severity>0</severity>
  </rule>
 
+ <!-- Require arrays to be defined by [] instead of array(). -->
+ <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+
  <!-- There MUST NOT be more than one statement per line. -->
  <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
 

--- a/src/AccessToken/Revoke.php
+++ b/src/AccessToken/Revoke.php
@@ -61,7 +61,7 @@ class Revoke
             }
         }
 
-        $body = Psr7\Utils::streamFor(http_build_query(array('token' => $token)));
+        $body = Psr7\Utils::streamFor(http_build_query(['token' => $token]));
         $request = new Request(
             'POST',
             Client::OAUTH2_REVOKE_URI,

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -18,22 +18,22 @@
 
 namespace Google\AccessToken;
 
-use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
-use Firebase\JWT\SignatureInvalidException;
-use Firebase\JWT\Key;
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use InvalidArgumentException;
-use phpseclib3\Crypt\PublicKeyLoader;
-use phpseclib3\Crypt\RSA\PublicKey;
-use Psr\Cache\CacheItemPoolInterface;
-use Google\Auth\Cache\MemoryCacheItemPool;
-use Google\Exception as GoogleException;
 use DateTime;
 use DomainException;
 use Exception;
-use ExpiredException; // Firebase v2
+use ExpiredException;
+use Firebase\JWT\ExpiredException as ExpiredExceptionV3;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Exception as GoogleException;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use InvalidArgumentException;
 use LogicException;
+use phpseclib3\Crypt\PublicKeyLoader;
+use phpseclib3\Crypt\RSA\PublicKey; // Firebase v2
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Wrapper around Google Access Tokens which provides convenience functions
@@ -74,7 +74,7 @@ class Verify
         }
 
         if (null === $cache) {
-            $cache = new MemoryCacheItemPool;
+            $cache = new MemoryCacheItemPool();
         }
 
         $this->http = $http;
@@ -231,7 +231,7 @@ class Verify
         }
 
         // @phpstan-ignore-next-line
-        return new $jwtClass;
+        return new $jwtClass();
     }
 
     private function getPublicKey($cert)

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -123,7 +123,7 @@ class Verify
 
                 // support HTTP and HTTPS issuers
                 // @see https://developers.google.com/identity/sign-in/web/backend-auth
-                $issuers = array(self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS);
+                $issuers = [self::OAUTH2_ISSUER, self::OAUTH2_ISSUER_HTTPS];
                 if (!isset($payload->iss) || !in_array($payload->iss, $issuers)) {
                     return false;
                 }
@@ -239,7 +239,7 @@ class Verify
         $bigIntClass = $this->getBigIntClass();
         $modulus = new $bigIntClass($this->jwt->urlsafeB64Decode($cert['n']), 256);
         $exponent = new $bigIntClass($this->jwt->urlsafeB64Decode($cert['e']), 256);
-        $component = array('n' => $modulus, 'e' => $exponent);
+        $component = ['n' => $modulus, 'e' => $exponent];
 
         if (class_exists('phpseclib3\Crypt\RSA\PublicKey')) {
             /** @var PublicKey $loader */

--- a/src/AuthHandler/AuthHandlerFactory.php
+++ b/src/AuthHandler/AuthHandlerFactory.php
@@ -17,9 +17,8 @@
 
 namespace Google\AuthHandler;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use Exception;
+use GuzzleHttp\ClientInterface;
 
 class AuthHandlerFactory
 {

--- a/src/AuthHandler/Guzzle5AuthHandler.php
+++ b/src/AuthHandler/Guzzle5AuthHandler.php
@@ -3,8 +3,8 @@
 namespace Google\AuthHandler;
 
 use Google\Auth\CredentialsLoader;
-use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\FetchAuthTokenCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\Subscriber\AuthTokenSubscriber;
 use Google\Auth\Subscriber\ScopedAccessTokenSubscriber;
 use Google\Auth\Subscriber\SimpleSubscriber;

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -3,8 +3,8 @@
 namespace Google\AuthHandler;
 
 use Google\Auth\CredentialsLoader;
-use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\FetchAuthTokenCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\Middleware\AuthTokenMiddleware;
 use Google\Auth\Middleware\ScopedAccessTokenMiddleware;
 use Google\Auth\Middleware\SimpleMiddleware;

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,32 +17,32 @@
 
 namespace Google;
 
+use BadMethodCallException;
+use DomainException;
 use Google\AccessToken\Revoke;
 use Google\AccessToken\Verify;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\Credentials\ServiceAccountCredentials;
+use Google\Auth\Credentials\UserRefreshCredentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Auth\OAuth2;
-use Google\Auth\Credentials\ServiceAccountCredentials;
-use Google\Auth\Credentials\UserRefreshCredentials;
 use Google\AuthHandler\AuthHandlerFactory;
 use Google\Http\REST;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Ring\Client\StreamHandler;
+use InvalidArgumentException;
+use LogicException;
+use Monolog\Handler\StreamHandler as MonologStreamHandler;
+use Monolog\Handler\SyslogHandler as MonologSyslogHandler;
+use Monolog\Logger;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler as MonologStreamHandler;
-use Monolog\Handler\SyslogHandler as MonologSyslogHandler;
-use BadMethodCallException;
-use DomainException;
-use InvalidArgumentException;
-use LogicException;
 use UnexpectedValueException;
 
 /**
@@ -185,7 +185,7 @@ class Client
             } else {
                 $this->setAuthConfig($this->config['credentials']);
             }
-                unset($this->config['credentials']);
+            unset($this->config['credentials']);
         }
 
         if (!is_null($this->config['scopes'])) {
@@ -446,7 +446,7 @@ class Client
                     $scopes,
                     $token['refresh_token']
                 );
-                    return $authHandler->attachCredentials(
+                return $authHandler->attachCredentials(
                         $http,
                         $credentials,
                         $this->config['token_callback']
@@ -1142,7 +1142,7 @@ class Client
 
     protected function createDefaultCache()
     {
-        return new MemoryCacheItemPool;
+        return new MemoryCacheItemPool();
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -107,7 +107,7 @@ class Client
      *
      * @param array $config
      */
-    public function __construct(array $config = array())
+    public function __construct(array $config = [])
     {
         $this->config = array_merge([
             'application_name' => '',
@@ -157,7 +157,7 @@ class Client
 
             // Task Runner retry configuration
             // @see Google\Task\Runner
-            'retry' => array(),
+            'retry' => [],
             'retry_map' => null,
 
             // Cache class implementing Psr\Cache\CacheItemPoolInterface.
@@ -508,9 +508,9 @@ class Client
                 $token = $json;
             } else {
                 // assume $token is just the token string
-                $token = array(
+                $token = [
                     'access_token' => $token,
-                );
+                ];
             }
         }
         if ($token == null) {
@@ -826,7 +826,7 @@ class Client
      */
     public function setScopes($scope_or_scopes)
     {
-        $this->requestedScopes = array();
+        $this->requestedScopes = [];
         $this->addScope($scope_or_scopes);
     }
 
@@ -1224,13 +1224,13 @@ class Client
 
         // create credentials using values supplied in setAuthConfig
         if ($signingKey) {
-            $serviceAccountCredentials = array(
+            $serviceAccountCredentials = [
                 'client_id' => $this->config['client_id'],
                 'client_email' => $this->config['client_email'],
                 'private_key' => $signingKey,
                 'type' => 'service_account',
                 'quota_project_id' => $this->config['quota_project'],
-            );
+            ];
             $credentials = CredentialsLoader::makeCredentials(
                 $scopes,
                 $serviceAccountCredentials
@@ -1284,13 +1284,11 @@ class Client
 
     private function createUserRefreshCredentials($scope, $refreshToken)
     {
-        $creds = array_filter(
-            array(
+        $creds = array_filter([
             'client_id' => $this->getClientId(),
             'client_secret' => $this->getClientSecret(),
             'refresh_token' => $refreshToken,
-            )
-        );
+        ]);
 
         return new UserRefreshCredentials($scope, $creds);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -447,10 +447,10 @@ class Client
                     $token['refresh_token']
                 );
                 return $authHandler->attachCredentials(
-                        $http,
-                        $credentials,
-                        $this->config['token_callback']
-                    );
+                    $http,
+                    $credentials,
+                    $this->config['token_callback']
+                );
             }
 
             return $authHandler->attachToken($http, $token, (array) $scopes);

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -37,16 +37,16 @@ class Batch
 {
     const BATCH_PATH = 'batch';
 
-    private static $CONNECTION_ESTABLISHED_HEADERS = array(
+    private static $CONNECTION_ESTABLISHED_HEADERS = [
         "HTTP/1.0 200 Connection established\r\n\r\n",
         "HTTP/1.1 200 Connection established\r\n\r\n",
-    );
+    ];
 
     /** @var string Multipart Boundary. */
     private $boundary;
 
     /** @var array service requests to be executed. */
-    private $requests = array();
+    private $requests = [];
 
     /** @var Client */
     private $client;
@@ -79,7 +79,7 @@ class Batch
     public function execute()
     {
         $body = '';
-        $classes = array();
+        $classes = [];
         $batchHttpTemplate = <<<EOF
 --%s
 Content-Type: application/http
@@ -124,10 +124,10 @@ EOF;
         $body .= "--{$this->boundary}--";
         $body = trim($body);
         $url = $this->rootUrl . '/' . $this->batchPath;
-        $headers = array(
+        $headers = [
             'Content-Type' => sprintf('multipart/mixed; boundary=%s', $this->boundary),
             'Content-Length' => (string) strlen($body),
-        );
+        ];
 
         $request = new Request(
             'POST',
@@ -141,7 +141,7 @@ EOF;
         return $this->parseResponse($response, $classes);
     }
 
-    public function parseResponse(ResponseInterface $response, $classes = array())
+    public function parseResponse(ResponseInterface $response, $classes = [])
     {
         $contentType = $response->getHeaderLine('content-type');
         $contentType = explode(';', $contentType);
@@ -157,7 +157,7 @@ EOF;
         if (!empty($body)) {
             $body = str_replace("--$boundary--", "--$boundary", $body);
             $parts = explode("--$boundary", $body);
-            $responses = array();
+            $responses = [];
             $requests = array_values($this->requests);
 
             foreach ($parts as $i => $part) {
@@ -200,7 +200,7 @@ EOF;
 
     private function parseRawHeaders($rawHeaders)
     {
-        $headers = array();
+        $headers = [];
         $responseHeaderLines = explode("\r\n", $rawHeaders);
         foreach ($responseHeaderLines as $headerLine) {
             if ($headerLine && strpos($headerLine, ':') !== false) {
@@ -252,6 +252,6 @@ EOF;
 
         $responseHeaders = $this->parseRawHeaders($responseHeaders);
 
-        return array($responseHeaders, $responseBody);
+        return [$responseHeaders, $responseBody];
     }
 }

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -18,7 +18,6 @@
 namespace Google\Http;
 
 use Google\Client;
-use Google\Http\REST;
 use Google\Service\Exception as GoogleServiceException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -115,7 +114,7 @@ EOF;
                 $key,
                 $firstLine,
                 $headers,
-                $content ? "\n".$content : ''
+                $content ? "\n" . $content : ''
             );
 
             $classes['response-' . $key] = $request->getHeaderLine('X-Php-Expected-Class');

--- a/src/Http/MediaFileUpload.php
+++ b/src/Http/MediaFileUpload.php
@@ -131,11 +131,11 @@ class MediaFileUpload
         }
 
         $lastBytePos = $this->progress + strlen($chunk) - 1;
-        $headers = array(
+        $headers = [
             'content-range' => "bytes $this->progress-$lastBytePos/$this->size",
             'content-length' => (string) strlen($chunk),
             'expect' => '',
-        );
+        ];
 
         $request = new Request(
             'PUT',
@@ -198,10 +198,10 @@ class MediaFileUpload
     public function resume($resumeUri)
     {
         $this->resumeUri = $resumeUri;
-        $headers = array(
+        $headers = [
             'content-range' => "bytes */$this->size",
             'content-length' => '0',
-        );
+        ];
         $httpRequest = new Request(
             'PUT',
             $this->resumeUri,
@@ -296,13 +296,13 @@ class MediaFileUpload
     private function fetchResumeUri()
     {
         $body = $this->request->getBody();
-        $headers = array(
+        $headers = [
             'content-type' => 'application/json; charset=UTF-8',
             'content-length' => $body->getSize(),
             'x-upload-content-type' => $this->mimeType,
             'x-upload-content-length' => $this->size,
             'expect' => '',
-        );
+        ];
         foreach ($headers as $key => $value) {
             $this->request = $this->request->withHeader($key, $value);
         }

--- a/src/Http/MediaFileUpload.php
+++ b/src/Http/MediaFileUpload.php
@@ -18,7 +18,6 @@
 namespace Google\Http;
 
 use Google\Client;
-use Google\Http\REST;
 use Google\Exception as GoogleException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
@@ -234,10 +233,10 @@ class MediaFileUpload
         if (self::UPLOAD_RESUMABLE_TYPE == $uploadType) {
             $contentType = $mimeType;
             $postBody = is_string($meta) ? $meta : json_encode($meta);
-        } else if (self::UPLOAD_MEDIA_TYPE == $uploadType) {
+        } elseif (self::UPLOAD_MEDIA_TYPE == $uploadType) {
             $contentType = $mimeType;
             $postBody = $this->data;
-        } else if (self::UPLOAD_MULTIPART_TYPE == $uploadType) {
+        } elseif (self::UPLOAD_MULTIPART_TYPE == $uploadType) {
             // This is a multipart/related upload.
             $boundary = $this->boundary ?: mt_rand();
             $boundary = str_replace('"', '', $boundary);

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -49,14 +49,14 @@ class REST
         ClientInterface $client,
         RequestInterface $request,
         $expectedClass = null,
-        $config = array(),
+        $config = [],
         $retryMap = null
     ) {
         $runner = new Runner(
             $config,
             sprintf('%s %s', $request->getMethod(), (string) $request->getUri()),
-            array(get_class(), 'doExecute'),
-            array($client, $request, $expectedClass)
+            [get_class(), 'doExecute'],
+            [$client, $request, $expectedClass]
         );
 
         if (null !== $retryMap) {

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -18,9 +18,8 @@
 namespace Google\Http;
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
-use Google\Client;
-use Google\Task\Runner;
 use Google\Service\Exception as GoogleServiceException;
+use Google\Task\Runner;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;

--- a/src/Model.php
+++ b/src/Model.php
@@ -35,9 +35,9 @@ class Model implements \ArrayAccess
      * instead - it will be replaced when converting to JSON with a real null.
      */
     const NULL_VALUE = "{}gapi-php-null";
-    protected $internal_gapi_mappings = array();
-    protected $modelData = array();
-    protected $processed = array();
+    protected $internal_gapi_mappings = [];
+    protected $modelData = [];
+    protected $processed = [];
 
     /**
      * Polymorphic - accepts a variable number of arguments dependent
@@ -66,7 +66,7 @@ class Model implements \ArrayAccess
             if (isset($this->modelData[$key])) {
                 $val = $this->modelData[$key];
             } elseif ($keyDataType == 'array' || $keyDataType == 'map') {
-                $val = array();
+                $val = [];
             } else {
                 $val = null;
             }
@@ -81,7 +81,7 @@ class Model implements \ArrayAccess
                     $this->modelData[$key] = new $keyType($val);
                 }
             } else if (is_array($val)) {
-                $arrayObject = array();
+                $arrayObject = [];
                 foreach ($val as $arrayIndex => $arrayItem) {
                     $arrayObject[$arrayIndex] = new $keyType($arrayItem);
                 }
@@ -106,7 +106,7 @@ class Model implements \ArrayAccess
             if ($keyType = $this->keyType($key)) {
                 $dataType = $this->dataType($key);
                 if ($dataType == 'array' || $dataType == 'map') {
-                    $this->$key = array();
+                    $this->$key = [];
                     foreach ($val as $itemKey => $itemVal) {
                         if ($itemVal instanceof $keyType) {
                             $this->{$key}[$itemKey] = $itemVal;
@@ -184,7 +184,7 @@ class Model implements \ArrayAccess
         if ($value instanceof Model) {
             return $value->toSimpleObject();
         } else if (is_array($value)) {
-            $return = array();
+            $return = [];
             foreach ($value as $key => $a_value) {
                 $a_value = $this->getSimpleValue($a_value);
                 if ($a_value !== null) {
@@ -324,7 +324,7 @@ class Model implements \ArrayAccess
    */
     private function camelCase($value)
     {
-        $value = ucwords(str_replace(array('-', '_'), ' ', $value));
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
         $value = str_replace(' ', '', $value);
         $value[0] = strtolower($value[0]);
         return $value;

--- a/src/Model.php
+++ b/src/Model.php
@@ -80,7 +80,7 @@ class Model implements \ArrayAccess
                 } else {
                     $this->modelData[$key] = new $keyType($val);
                 }
-            } else if (is_array($val)) {
+            } elseif (is_array($val)) {
                 $arrayObject = [];
                 foreach ($val as $arrayIndex => $arrayItem) {
                     $arrayObject[$arrayIndex] = new $keyType($arrayItem);
@@ -183,7 +183,7 @@ class Model implements \ArrayAccess
     {
         if ($value instanceof Model) {
             return $value->toSimpleObject();
-        } else if (is_array($value)) {
+        } elseif (is_array($value)) {
             $return = [];
             foreach ($value as $key => $a_value) {
                 $a_value = $this->getSimpleValue($a_value);

--- a/src/Service/Exception.php
+++ b/src/Service/Exception.php
@@ -24,7 +24,7 @@ class Exception extends GoogleException
     /**
      * Optional list of errors returned in a JSON body of an HTTP error response.
      */
-    protected $errors = array();
+    protected $errors = [];
 
     /**
      * Override default constructor to add the ability to set $errors and a retry
@@ -40,7 +40,7 @@ class Exception extends GoogleException
         $message,
         $code = 0,
         Exception $previous = null,
-        $errors = array()
+        $errors = []
     ) {
         if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
             parent::__construct($message, $code, $previous);

--- a/src/Service/Resource.php
+++ b/src/Service/Resource.php
@@ -17,9 +17,9 @@
 
 namespace Google\Service;
 
-use Google\Model;
-use Google\Http\MediaFileUpload;
 use Google\Exception as GoogleException;
+use Google\Http\MediaFileUpload;
+use Google\Model;
 use Google\Utils\UriTemplate;
 use GuzzleHttp\Psr7\Request;
 
@@ -114,7 +114,7 @@ class Resource
                 // to use the smart method to create a simple object for
                 // for JSONification.
                 $parameters['postBody'] = $parameters['postBody']->toSimpleObject();
-            } else if (is_object($parameters['postBody'])) {
+            } elseif (is_object($parameters['postBody'])) {
                 // If the post body is another kind of object, we will try and
                 // wrangle it into a sensible format.
                 $parameters['postBody'] =
@@ -283,7 +283,7 @@ class Resource
             }
             if ($paramSpec['location'] == 'path') {
                 $uriTemplateVars[$paramName] = $paramSpec['value'];
-            } else if ($paramSpec['location'] == 'query') {
+            } elseif ($paramSpec['location'] == 'query') {
                 if (is_array($paramSpec['value'])) {
                     foreach ($paramSpec['value'] as $value) {
                         $queryVars[] = $paramName . '=' . rawurlencode(rawurldecode($value));

--- a/src/Service/Resource.php
+++ b/src/Service/Resource.php
@@ -32,18 +32,18 @@ use GuzzleHttp\Psr7\Request;
 class Resource
 {
     // Valid query parameters that work, but don't appear in discovery.
-    private $stackParameters = array(
-        'alt' => array('type' => 'string', 'location' => 'query'),
-        'fields' => array('type' => 'string', 'location' => 'query'),
-        'trace' => array('type' => 'string', 'location' => 'query'),
-        'userIp' => array('type' => 'string', 'location' => 'query'),
-        'quotaUser' => array('type' => 'string', 'location' => 'query'),
-        'data' => array('type' => 'string', 'location' => 'body'),
-        'mimeType' => array('type' => 'string', 'location' => 'header'),
-        'uploadType' => array('type' => 'string', 'location' => 'query'),
-        'mediaUpload' => array('type' => 'complex', 'location' => 'query'),
-        'prettyPrint' => array('type' => 'string', 'location' => 'query'),
-    );
+    private $stackParameters = [
+        'alt' => ['type' => 'string', 'location' => 'query'],
+        'fields' => ['type' => 'string', 'location' => 'query'],
+        'trace' => ['type' => 'string', 'location' => 'query'],
+        'userIp' => ['type' => 'string', 'location' => 'query'],
+        'quotaUser' => ['type' => 'string', 'location' => 'query'],
+        'data' => ['type' => 'string', 'location' => 'body'],
+        'mimeType' => ['type' => 'string', 'location' => 'header'],
+        'uploadType' => ['type' => 'string', 'location' => 'query'],
+        'mediaUpload' => ['type' => 'complex', 'location' => 'query'],
+        'prettyPrint' => ['type' => 'string', 'location' => 'query'],
+    ];
 
     /** @var string $rootUrl */
     private $rootUrl;
@@ -72,7 +72,7 @@ class Resource
         $this->resourceName = $resourceName;
         $this->methods = is_array($resource) && isset($resource['methods']) ?
         $resource['methods'] :
-        array($resourceName => $resource);
+        [$resourceName => $resource];
     }
 
     /**
@@ -90,11 +90,11 @@ class Resource
         if (! isset($this->methods[$name])) {
             $this->client->getLogger()->error(
                 'Service method unknown',
-                array(
+                [
                     'service' => $this->serviceName,
                     'resource' => $this->resourceName,
                     'method' => $name
-                )
+                ]
             );
 
             throw new GoogleException(
@@ -133,7 +133,7 @@ class Resource
         }
 
         if (!isset($method['parameters'])) {
-            $method['parameters'] = array();
+            $method['parameters'] = [];
         }
 
         $method['parameters'] = array_merge(
@@ -145,12 +145,12 @@ class Resource
             if ($key != 'postBody' && !isset($method['parameters'][$key])) {
                 $this->client->getLogger()->error(
                     'Service parameter unknown',
-                    array(
+                    [
                         'service' => $this->serviceName,
                         'resource' => $this->resourceName,
                         'method' => $name,
                         'parameter' => $key
-                    )
+                    ]
                 );
                 throw new GoogleException("($name) unknown parameter: '$key'");
             }
@@ -164,12 +164,12 @@ class Resource
             ) {
                 $this->client->getLogger()->error(
                     'Service parameter missing',
-                    array(
+                    [
                         'service' => $this->serviceName,
                         'resource' => $this->resourceName,
                         'method' => $name,
                         'parameter' => $paramName
-                    )
+                    ]
                 );
                 throw new GoogleException("($name) missing required param: '$paramName'");
             }
@@ -186,12 +186,12 @@ class Resource
 
         $this->client->getLogger()->info(
             'Service Call',
-            array(
+            [
                 'service' => $this->serviceName,
                 'resource' => $this->resourceName,
                 'method' => $name,
                 'arguments' => $parameters,
-            )
+            ]
         );
 
         // build the service uri
@@ -275,8 +275,8 @@ class Resource
             }
             $requestUrl = $this->rootUrl . $requestUrl;
         }
-        $uriTemplateVars = array();
-        $queryVars = array();
+        $uriTemplateVars = [];
+        $queryVars = [];
         foreach ($params as $paramName => $paramSpec) {
             if ($paramSpec['type'] == 'boolean') {
                 $paramSpec['value'] = $paramSpec['value'] ? 'true' : 'false';

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -18,9 +18,9 @@
 namespace Google\Task;
 
 use Composer\Script\Event;
+use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use InvalidArgumentException;
 
 class Composer
 {

--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -102,7 +102,7 @@ class Runner
         $config,
         $name,
         $action,
-        array $arguments = array()
+        array $arguments = []
     ) {
         if (isset($config['initial_delay'])) {
             if ($config['initial_delay'] < 0) {
@@ -269,7 +269,7 @@ class Runner
      *
      * @return integer
      */
-    public function allowedRetries($code, $errors = array())
+    public function allowedRetries($code, $errors = [])
     {
         if (isset($this->retryMap[$code])) {
             return $this->retryMap[$code];

--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -98,7 +98,8 @@ class Runner
      * @param array $arguments The task arguments
      * @throws \Google\Task\Exception when misconfigured
      */
-    public function __construct( // @phpstan-ignore-line
+    // @phpstan-ignore-next-line
+    public function __construct(
         $config,
         $name,
         $action,

--- a/src/Utils/UriTemplate.php
+++ b/src/Utils/UriTemplate.php
@@ -50,7 +50,7 @@ class UriTemplate
      */
     private $reserved = [
         "=", ",", "!", "@", "|", ":", "/", "?", "#",
-        "[", "]",'$', "&", "'", "(", ")", "*", "+", ";"
+        "[", "]", '$', "&", "'", "(", ")", "*", "+", ";"
     ];
     private $reservedEncoded = [
         "%3D", "%2C", "%21", "%40", "%7C", "%3A", "%2F", "%3F",
@@ -138,7 +138,6 @@ class UriTemplate
             if ($data || ($data !== false && $prefix_on_missing)) {
                 $data = $prefix . $data;
             }
-
         } else {
             // If no operator we replace with the defaults.
             $data = $this->replaceVars($data, $parameters);
@@ -252,7 +251,7 @@ class UriTemplate
                     }
                     break;
             }
-        } else if ($tag_empty) {
+        } elseif ($tag_empty) {
             // If we are just indicating empty values with their key name, return that.
             return $key;
         } else {
@@ -314,7 +313,7 @@ class UriTemplate
                 $combine_on_empty
             );
             if ($response === false) {
-                  continue;
+                continue;
             }
             $ret[] = $response;
         }

--- a/src/Utils/UriTemplate.php
+++ b/src/Utils/UriTemplate.php
@@ -33,30 +33,30 @@ class UriTemplate
      * modify the way in which the variables inside are
      * processed.
      */
-    private $operators = array(
-      "+" => "reserved",
-      "/" => "segments",
-      "." => "dotprefix",
-      "#" => "fragment",
-      ";" => "semicolon",
-      "?" => "form",
-      "&" => "continuation"
-    );
+    private $operators = [
+        "+" => "reserved",
+        "/" => "segments",
+        "." => "dotprefix",
+        "#" => "fragment",
+        ";" => "semicolon",
+        "?" => "form",
+        "&" => "continuation"
+    ];
 
     /**
      * @var array<string>
      * These are the characters which should not be URL encoded in reserved
      * strings.
      */
-    private $reserved = array(
-      "=", ",", "!", "@", "|", ":", "/", "?", "#",
-      "[", "]",'$', "&", "'", "(", ")", "*", "+", ";"
-    );
-    private $reservedEncoded = array(
-    "%3D", "%2C", "%21", "%40", "%7C", "%3A", "%2F", "%3F",
-    "%23", "%5B", "%5D", "%24", "%26", "%27", "%28", "%29",
-    "%2A", "%2B", "%3B"
-    );
+    private $reserved = [
+        "=", ",", "!", "@", "|", ":", "/", "?", "#",
+        "[", "]",'$', "&", "'", "(", ")", "*", "+", ";"
+    ];
+    private $reservedEncoded = [
+        "%3D", "%2C", "%21", "%40", "%7C", "%3A", "%2F", "%3F",
+        "%23", "%5B", "%5D", "%24", "%26", "%27", "%28", "%29",
+        "%2A", "%2B", "%3B"
+    ];
 
     public function parse($string, array $parameters)
     {
@@ -220,7 +220,7 @@ class UriTemplate
                     $value = $this->getValue($parameters[$key], $length);
                     break;
                 case self::TYPE_LIST:
-                    $values = array();
+                    $values = [];
                     foreach ($parameters[$key] as $pkey => $pvalue) {
                         $pvalue = $this->getValue($pvalue, $length);
                         if ($combine && $explode) {
@@ -235,7 +235,7 @@ class UriTemplate
                     }
                     break;
                 case self::TYPE_MAP:
-                    $values = array();
+                    $values = [];
                     foreach ($parameters[$key] as $pkey => $pvalue) {
                         $pvalue = $this->getValue($pvalue, $length);
                         if ($explode) {
@@ -302,7 +302,7 @@ class UriTemplate
         $tag_empty,
         $combine_on_empty
     ) {
-        $ret = array();
+        $ret = [];
         foreach ($vars as $var) {
             $response = $this->combine(
                 $var,

--- a/src/aliases.php
+++ b/src/aliases.php
@@ -43,24 +43,64 @@ class Google_Task_Composer extends \Google\Task\Composer
 
 /** @phpstan-ignore-next-line */
 if (\false) {
-    class Google_AccessToken_Revoke extends \Google\AccessToken\Revoke {}
-    class Google_AccessToken_Verify extends \Google\AccessToken\Verify {}
-    class Google_AuthHandler_AuthHandlerFactory extends \Google\AuthHandler\AuthHandlerFactory {}
-    class Google_AuthHandler_Guzzle5AuthHandler extends \Google\AuthHandler\Guzzle5AuthHandler {}
-    class Google_AuthHandler_Guzzle6AuthHandler extends \Google\AuthHandler\Guzzle6AuthHandler {}
-    class Google_AuthHandler_Guzzle7AuthHandler extends \Google\AuthHandler\Guzzle7AuthHandler {}
-    class Google_Client extends \Google\Client {}
-    class Google_Collection extends \Google\Collection {}
-    class Google_Exception extends \Google\Exception {}
-    class Google_Http_Batch extends \Google\Http\Batch {}
-    class Google_Http_MediaFileUpload extends \Google\Http\MediaFileUpload {}
-    class Google_Http_REST extends \Google\Http\REST {}
-    class Google_Model extends \Google\Model {}
-    class Google_Service extends \Google\Service {}
-    class Google_Service_Exception extends \Google\Service\Exception {}
-    class Google_Service_Resource extends \Google\Service\Resource {}
-    class Google_Task_Exception extends \Google\Task\Exception {}
-    interface Google_Task_Retryable extends \Google\Task\Retryable {}
-    class Google_Task_Runner extends \Google\Task\Runner {}
-    class Google_Utils_UriTemplate extends \Google\Utils\UriTemplate {}
+    class Google_AccessToken_Revoke extends \Google\AccessToken\Revoke
+    {
+    }
+    class Google_AccessToken_Verify extends \Google\AccessToken\Verify
+    {
+    }
+    class Google_AuthHandler_AuthHandlerFactory extends \Google\AuthHandler\AuthHandlerFactory
+    {
+    }
+    class Google_AuthHandler_Guzzle5AuthHandler extends \Google\AuthHandler\Guzzle5AuthHandler
+    {
+    }
+    class Google_AuthHandler_Guzzle6AuthHandler extends \Google\AuthHandler\Guzzle6AuthHandler
+    {
+    }
+    class Google_AuthHandler_Guzzle7AuthHandler extends \Google\AuthHandler\Guzzle7AuthHandler
+    {
+    }
+    class Google_Client extends \Google\Client
+    {
+    }
+    class Google_Collection extends \Google\Collection
+    {
+    }
+    class Google_Exception extends \Google\Exception
+    {
+    }
+    class Google_Http_Batch extends \Google\Http\Batch
+    {
+    }
+    class Google_Http_MediaFileUpload extends \Google\Http\MediaFileUpload
+    {
+    }
+    class Google_Http_REST extends \Google\Http\REST
+    {
+    }
+    class Google_Model extends \Google\Model
+    {
+    }
+    class Google_Service extends \Google\Service
+    {
+    }
+    class Google_Service_Exception extends \Google\Service\Exception
+    {
+    }
+    class Google_Service_Resource extends \Google\Service\Resource
+    {
+    }
+    class Google_Task_Exception extends \Google\Task\Exception
+    {
+    }
+    interface Google_Task_Retryable extends \Google\Task\Retryable
+    {
+    }
+    class Google_Task_Runner extends \Google\Task\Runner
+    {
+    }
+    class Google_Utils_UriTemplate extends \Google\Utils\UriTemplate
+    {
+    }
 }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -159,7 +159,7 @@ class BaseTest extends TestCase
         $clientId = getenv('GOOGLE_CLIENT_ID') ?: null;
         $clientSecret = getenv('GOOGLE_CLIENT_SECRET') ?: null;
 
-        return array($clientId, $clientSecret);
+        return [$clientId, $clientSecret];
     }
 
     protected function checkClientCredentials()

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -211,24 +211,24 @@ class ClientTest extends BaseTest
         $this->onlyGuzzle6Or7();
 
         $client = new Client();
-        $client->setScopes(array("scope1", "scope2"));
+        $client->setScopes(["scope1", "scope2"]);
         $scopes = $client->prepareScopes();
         $this->assertEquals("scope1 scope2", $scopes);
 
-        $client->setScopes(array("", "scope2"));
+        $client->setScopes(["", "scope2"]);
         $scopes = $client->prepareScopes();
         $this->assertEquals(" scope2", $scopes);
 
         $client->setScopes("scope2");
         $client->addScope("scope3");
-        $client->addScope(array("scope4", "scope5"));
+        $client->addScope(["scope4", "scope5"]);
         $scopes = $client->prepareScopes();
         $this->assertEquals("scope2 scope3 scope4 scope5", $scopes);
 
         $client->setClientId('test1');
         $client->setRedirectUri('http://localhost/');
         $client->setState('xyz');
-        $client->setScopes(array("http://test.com", "scope2"));
+        $client->setScopes(["http://test.com", "scope2"]);
         $scopes = $client->prepareScopes();
         $this->assertEquals("http://test.com scope2", $scopes);
         $this->assertEquals(
@@ -309,7 +309,7 @@ class ClientTest extends BaseTest
             $this->assertEquals('invalid json token', $e->getMessage());
         }
 
-        $token = array('access_token' => 'token');
+        $token = ['access_token' => 'token'];
         $client->setAccessToken($token);
         $this->assertEquals($token, $client->getAccessToken());
     }
@@ -531,10 +531,10 @@ class ClientTest extends BaseTest
     public function testRefreshTokenIsSetOnRefresh()
     {
         $refreshToken = 'REFRESH_TOKEN';
-        $token = json_encode(array(
+        $token = json_encode([
             'access_token' => 'xyz',
             'id_token' => 'ID_TOKEN',
-        ));
+        ]);
         $postBody = $this->prophesize('Psr\Http\Message\StreamInterface');
         $postBody->__toString()
             ->shouldBeCalledTimes(1)
@@ -584,11 +584,11 @@ class ClientTest extends BaseTest
     public function testRefreshTokenIsNotSetWhenNewRefreshTokenIsReturned()
     {
         $refreshToken = 'REFRESH_TOKEN';
-        $token = json_encode(array(
+        $token = json_encode([
             'access_token' => 'xyz',
             'id_token' => 'ID_TOKEN',
             'refresh_token' => 'NEW_REFRESH_TOKEN'
-        ));
+        ]);
 
         $postBody = $this->prophesize('GuzzleHttp\Psr7\Stream');
         $postBody->__toString()

--- a/tests/Google/Http/MediaFileUploadTest.php
+++ b/tests/Google/Http/MediaFileUploadTest.php
@@ -60,7 +60,7 @@ class MediaFileUploadTest extends BaseTest
 
         // Test multipart uploads
         $media = new MediaFileUpload($client, $request, 'image/png', 'a', false);
-        $this->assertEquals('multipart', $media->getUploadType(array('a' => 'b')));
+        $this->assertEquals('multipart', $media->getUploadType(['a' => 'b']));
     }
 
     public function testProcess()

--- a/tests/Google/Http/RESTTest.php
+++ b/tests/Google/Http/RESTTest.php
@@ -45,8 +45,8 @@ class RESTTest extends BaseTest
         $decoded = $this->rest->decodeHttpResponse($response, $this->request);
         $this->assertEquals($response, $decoded);
 
-        foreach (array(200, 201) as $code) {
-            $headers = array('foo', 'bar');
+        foreach ([200, 201] as $code) {
+            $headers = ['foo', 'bar'];
             $stream = Psr7\Utils::streamFor('{"a": 1}');
             $response = new Response($code, $headers, $stream);
 
@@ -60,7 +60,7 @@ class RESTTest extends BaseTest
         $client = $this->getClient();
 
         $request =  new Request('GET', 'http://www.example.com?alt=media');
-        $headers = array();
+        $headers = [];
         $stream = Psr7\Utils::streamFor('thisisnotvalidjson');
         $response = new Response(200, $headers, $stream);
 
@@ -88,7 +88,7 @@ class RESTTest extends BaseTest
     public function testDecodeEmptyResponse()
     {
         $stream = Psr7\Utils::streamFor('{}');
-        $response = new Response(200, array(), $stream);
+        $response = new Response(200, [], $stream);
         $decoded = $this->rest->decodeHttpResponse($response, $this->request);
         $this->assertEquals('{}', (string) $decoded->getBody());
     }
@@ -104,7 +104,7 @@ class RESTTest extends BaseTest
                 }
             }'
         );
-        $response = new Response(500, array(), $stream);
+        $response = new Response(500, [], $stream);
         $this->rest->decodeHttpResponse($response, $this->request);
     }
 
@@ -128,7 +128,7 @@ class RESTTest extends BaseTest
                 }
             }'
         );
-        $response = new Response(401, array(), $stream);
+        $response = new Response(401, [], $stream);
         $this->rest->decodeHttpResponse($response, $this->request);
     }
 
@@ -136,7 +136,7 @@ class RESTTest extends BaseTest
     {
         $this->expectException(ServiceException::class);
         $stream = Psr7\Utils::streamFor('Not Found');
-        $response = new Response(404, array(), $stream);
+        $response = new Response(404, [], $stream);
         $this->rest->decodeHttpResponse($response, $this->request);
     }
 }

--- a/tests/Google/ModelTest.php
+++ b/tests/Google/ModelTest.php
@@ -114,7 +114,7 @@ class ModelTest extends BaseTest
         $creative->setBuyerCreativeId('12345');
         $creative->setAdvertiserName('Hi');
         $creative->setHTMLSnippet("<p>Foo!</p>");
-        $creative->setClickThroughUrl(array('http://somedomain.com'));
+        $creative->setClickThroughUrl(['http://somedomain.com']);
         $creative->setWidth(100);
         $creative->setHeight(100);
         $data = json_decode(json_encode($creative->toSimpleObject()), true);
@@ -135,7 +135,7 @@ class ModelTest extends BaseTest
         $model3 = new Model();
         $model3->publicE = 54321;
         $model3->publicF = null;
-        $model->publicG = array($model3, "hello", false);
+        $model->publicG = [$model3, "hello", false];
         $model->publicH = false;
         $model->publicI = 0;
         $string = json_encode($model->toSimpleObject());

--- a/tests/Google/Service/AdSenseTest.php
+++ b/tests/Google/Service/AdSenseTest.php
@@ -458,12 +458,12 @@ class AdSenseTest extends BaseTest
 
     private function getReportOptParams()
     {
-        return array(
-            'metric' => array('PAGE_VIEWS', 'AD_REQUESTS'),
-            'dimension' => array ('DATE', 'AD_CLIENT_ID'),
-            'sort' => array('DATE'),
-            'filter' => array('COUNTRY_NAME==United States'),
-        );
+        return [
+            'metric' => ['PAGE_VIEWS', 'AD_REQUESTS'],
+            'dimension' =>  ['DATE', 'AD_CLIENT_ID'],
+            'sort' => ['DATE'],
+            'filter' => ['COUNTRY_NAME==United States'],
+        ];
     }
 
     private function checkReport($report)

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -73,17 +73,17 @@ class ResourceTest extends BaseTest
             $this->service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
-        $resource->call("someothermethod", array());
+        $resource->call("someothermethod", []);
     }
 
     public function testCall()
@@ -92,17 +92,17 @@ class ResourceTest extends BaseTest
             $this->service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                             "path" => "method/path",
                             "httpMethod" => "POST",
-                        )
-                )
-            )
+                        ]
+                ]
+            ]
         );
-        $request = $resource->call("testMethod", array(array()));
+        $request = $resource->call("testMethod", [[]]);
         $this->assertEquals("https://test.example.com/method/path", (string) $request->getUri());
         $this->assertEquals("POST", $request->getMethod());
     }
@@ -114,17 +114,17 @@ class ResourceTest extends BaseTest
             $this->service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
-        $request = $resource->call("testMethod", array(array()));
+        $request = $resource->call("testMethod", [[]]);
         $this->assertEquals("https://sample.example.com/method/path", (string) $request->getUri());
         $this->assertEquals("POST", $request->getMethod());
     }
@@ -142,17 +142,17 @@ class ResourceTest extends BaseTest
             $this->service,
             'test',
             'testResource',
-            array(
-                "methods" => array(
-                    'testMethod' => array(
-                        'parameters' => array(),
+            [
+                "methods" => [
+                    'testMethod' => [
+                        'parameters' => [],
                         'path' => '/admin/directory_v1/watch/stop',
                         'httpMethod' => 'POST',
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
-        $request = $resource->call('testMethod', array(array()));
+        $request = $resource->call('testMethod', [[]]);
         $this->assertEquals('https://test.example.com/admin/directory_v1/watch/stop', (string) $request->getUri());
     }
 
@@ -161,10 +161,10 @@ class ResourceTest extends BaseTest
         $restPath = "plus/{u}";
         $service = new GoogleService($this->client->reveal());
         $service->servicePath = "http://localhost/";
-        $resource = new GoogleResource($service, 'test', 'testResource', array());
+        $resource = new GoogleResource($service, 'test', 'testResource', []);
 
         // Test Path
-        $params = array();
+        $params = [];
         $params['u']['type'] = 'string';
         $params['u']['location'] = 'path';
         $params['u']['value'] = 'me';
@@ -172,7 +172,7 @@ class ResourceTest extends BaseTest
         $this->assertEquals("http://localhost/plus/me", $value);
 
         // Test Query
-        $params = array();
+        $params = [];
         $params['u']['type'] = 'string';
         $params['u']['location'] = 'query';
         $params['u']['value'] = 'me';
@@ -180,7 +180,7 @@ class ResourceTest extends BaseTest
         $this->assertEquals("http://localhost/plus?u=me", $value);
 
         // Test Booleans
-        $params = array();
+        $params = [];
         $params['u']['type'] = 'boolean';
         $params['u']['location'] = 'path';
         $params['u']['value'] = '1';
@@ -192,7 +192,7 @@ class ResourceTest extends BaseTest
         $this->assertEquals("http://localhost/plus?u=true", $value);
 
         // Test encoding
-        $params = array();
+        $params = [];
         $params['u']['type'] = 'string';
         $params['u']['location'] = 'query';
         $params['u']['value'] = '@me/';
@@ -236,15 +236,15 @@ class ResourceTest extends BaseTest
             $service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $expectedClass = 'ThisShouldBeIgnored';
@@ -289,15 +289,15 @@ class ResourceTest extends BaseTest
             $service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         try {
@@ -346,15 +346,15 @@ class ResourceTest extends BaseTest
             $service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         try {
@@ -392,15 +392,15 @@ class ResourceTest extends BaseTest
             $service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         $expectedClass = 'ThisShouldBeIgnored';
@@ -451,20 +451,20 @@ class ResourceTest extends BaseTest
             $service,
             "test",
             "testResource",
-            array(
-                "methods" => array(
-                    "testMethod" => array(
-                        "parameters" => array(),
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
                         "path" => "method/path",
                         "httpMethod" => "POST",
-                    )
-                )
-            )
+                    ]
+                ]
+            ]
         );
 
         try {
 
-            $decoded = $resource->call('testMethod', array(array()));
+            $decoded = $resource->call('testMethod', [[]]);
             $this->fail('should have thrown exception');
         } catch (ServiceException $e) {
             $this->assertEquals($errors, $e->getErrors());

--- a/tests/Google/Service/YouTubeTest.php
+++ b/tests/Google/Service/YouTubeTest.php
@@ -33,7 +33,7 @@ class YouTubeTest extends BaseTest
     public function testMissingFieldsAreNull()
     {
         $parts = "id,brandingSettings";
-        $opts = array("mine" => true);
+        $opts = ["mine" => true];
         $channels = $this->youtube->channels->listChannels($parts, $opts);
 
         $newChannel = new YouTube\Channel();
@@ -75,7 +75,7 @@ class YouTubeTest extends BaseTest
         $ping = new YouTube\ChannelConversionPing();
         $ping->setContext("hello");
         $pings = new YouTube\ChannelConversionPings();
-        $pings->setPings(array($ping));
+        $pings->setPings([$ping]);
         $simplePings = $pings->toSimpleObject();
         $this->assertObjectHasAttribute('context', $simplePings->pings[0]);
         $this->assertObjectNotHasAttribute('conversionUrl', $simplePings->pings[0]);

--- a/tests/Google/ServiceTest.php
+++ b/tests/Google/ServiceTest.php
@@ -94,38 +94,34 @@ class ServiceTest extends TestCase
     {
         $model = new TestModel();
 
-        $model->mapTypes(
-            array(
+        $model->mapTypes([
             'name' => 'asdf',
             'gender' => 'z',
-            )
-        );
+        ]);
         $this->assertEquals('asdf', $model->name);
         $this->assertEquals('z', $model->gender);
-        $model->mapTypes(
-            array(
-                '__infoType' => 'Google_Model',
-                '__infoDataType' => 'map',
-                'info' => array (
-                    'location' => 'mars',
-                    'timezone' => 'mst',
-                ),
-                'name' => 'asdf',
-                'gender' => 'z',
-            )
-        );
+        $model->mapTypes([
+            '__infoType' => 'Google_Model',
+            '__infoDataType' => 'map',
+            'info' =>  [
+                'location' => 'mars',
+                'timezone' => 'mst',
+            ],
+            'name' => 'asdf',
+            'gender' => 'z',
+        ]);
         $this->assertEquals('asdf', $model->name);
         $this->assertEquals('z', $model->gender);
 
         $this->assertFalse($model->isAssociativeArray(""));
         $this->assertFalse($model->isAssociativeArray(false));
         $this->assertFalse($model->isAssociativeArray(null));
-        $this->assertFalse($model->isAssociativeArray(array()));
-        $this->assertFalse($model->isAssociativeArray(array(1, 2)));
-        $this->assertFalse($model->isAssociativeArray(array(1 => 2)));
+        $this->assertFalse($model->isAssociativeArray([]));
+        $this->assertFalse($model->isAssociativeArray([1, 2]));
+        $this->assertFalse($model->isAssociativeArray([1 => 2]));
 
-        $this->assertTrue($model->isAssociativeArray(array('test' => 'a')));
-        $this->assertTrue($model->isAssociativeArray(array("a", "b" => 2)));
+        $this->assertTrue($model->isAssociativeArray(['test' => 'a']));
+        $this->assertTrue($model->isAssociativeArray(["a", "b" => 2]));
     }
 
     public function testConfigConstructor()

--- a/tests/Google/Task/RunnerTest.php
+++ b/tests/Google/Task/RunnerTest.php
@@ -38,7 +38,7 @@ class RunnerTest extends BaseTest
 
     private $mockedCallsCount = 0;
     private $currentMockedCall = 0;
-    private $mockedCalls = array();
+    private $mockedCalls = [];
     private $retryMap;
     private $retryConfig;
 
@@ -62,7 +62,7 @@ class RunnerTest extends BaseTest
     public function testOneRestRetryWithError($errorCode, $errorBody = '{}')
     {
         $this->expectException(ServiceException::class);
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $this->setNextResponses(2, $errorCode, $errorBody)->makeRequest();
     }
 
@@ -75,7 +75,7 @@ class RunnerTest extends BaseTest
     ) {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponses(6, $errorCode, $errorBody)->makeRequest();
     }
 
@@ -84,7 +84,7 @@ class RunnerTest extends BaseTest
    */
     public function testOneRestRetryWithSuccess($errorCode, $errorBody = '{}')
     {
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $result = $this->setNextResponse($errorCode, $errorBody)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -99,7 +99,7 @@ class RunnerTest extends BaseTest
         $errorCode,
         $errorBody = '{}'
     ) {
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $result = $this->setNextResponses(2, $errorCode, $errorBody)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -116,19 +116,19 @@ class RunnerTest extends BaseTest
     ) {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryMap(array());
+        $this->setRetryMap([]);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponse($errorCode, $errorBody)->makeRequest();
     }
 
     public function testCustomRestRetryMapAddsNewHandlers()
     {
         $this->setRetryMap(
-            array('403' => Runner::TASK_RETRY_ALWAYS)
+            ['403' => Runner::TASK_RETRY_ALWAYS]
         );
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $result = $this->setNextResponses(2, 403)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -144,10 +144,10 @@ class RunnerTest extends BaseTest
         $this->expectException(ServiceException::class);
 
         $this->setRetryMap(
-            array('403' => $limit)
+            ['403' => $limit]
         );
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponses($limit + 1, 403)->makeRequest();
     }
 
@@ -162,7 +162,7 @@ class RunnerTest extends BaseTest
 
         $this->assertTaskTimeGreaterThanOrEqual(
             $minTime,
-            array($this, 'makeRequest'),
+            [$this, 'makeRequest'],
             $config['initial_delay'] / 10
         );
     }
@@ -186,7 +186,7 @@ class RunnerTest extends BaseTest
     {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $this->setNextResponsesThrow(2, $errorMessage, $errorCode)->makeRequest();
     }
 
@@ -200,7 +200,7 @@ class RunnerTest extends BaseTest
     ) {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponsesThrow(6, $errorMessage, $errorCode)->makeRequest();
     }
 
@@ -210,7 +210,7 @@ class RunnerTest extends BaseTest
    */
     public function testOneCurlRetryWithSuccess($errorCode, $errorMessage = '')
     {
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $result = $this->setNextResponseThrows($errorMessage, $errorCode)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -226,7 +226,7 @@ class RunnerTest extends BaseTest
         $errorCode,
         $errorMessage = ''
     ) {
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $result = $this->setNextResponsesThrow(2, $errorMessage, $errorCode)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -244,9 +244,9 @@ class RunnerTest extends BaseTest
     ) {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryMap(array());
+        $this->setRetryMap([]);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponseThrows($errorMessage, $errorCode)->makeRequest();
     }
 
@@ -256,10 +256,10 @@ class RunnerTest extends BaseTest
     public function testCustomCurlRetryMapAddsNewHandlers()
     {
         $this->setRetryMap(
-            array(CURLE_COULDNT_RESOLVE_PROXY => Runner::TASK_RETRY_ALWAYS)
+            [CURLE_COULDNT_RESOLVE_PROXY => Runner::TASK_RETRY_ALWAYS]
         );
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $result = $this->setNextResponsesThrow(2, '', CURLE_COULDNT_RESOLVE_PROXY)
                    ->setNextResponse(200, '{"success": true}')
                    ->makeRequest();
@@ -276,10 +276,10 @@ class RunnerTest extends BaseTest
         $this->expectException(ServiceException::class);
 
         $this->setRetryMap(
-            array(CURLE_COULDNT_RESOLVE_PROXY => $limit)
+            [CURLE_COULDNT_RESOLVE_PROXY => $limit]
         );
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextResponsesThrow($limit + 1, '', CURLE_COULDNT_RESOLVE_PROXY)
          ->makeRequest();
     }
@@ -296,7 +296,7 @@ class RunnerTest extends BaseTest
 
         $this->assertTaskTimeGreaterThanOrEqual(
             $minTime,
-            array($this, 'makeRequest'),
+            [$this, 'makeRequest'],
             $config['initial_delay'] / 10
         );
     }
@@ -313,7 +313,7 @@ class RunnerTest extends BaseTest
         new Runner(
             $this->retryConfig,
             '',
-            array($this, 'testBadTaskConfig')
+            [$this, 'testBadTaskConfig']
         );
     }
 
@@ -339,7 +339,7 @@ class RunnerTest extends BaseTest
     {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $this->setNextTasksAllowedRetries(2, Runner::TASK_RETRY_ALWAYS)
          ->runTask();
     }
@@ -348,14 +348,14 @@ class RunnerTest extends BaseTest
     {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextTasksAllowedRetries(6, Runner::TASK_RETRY_ALWAYS)
          ->runTask();
     }
 
     public function testOneTaskRetryWithSuccess()
     {
-        $this->setRetryConfig(array('retries' => 1));
+        $this->setRetryConfig(['retries' => 1]);
         $result = $this->setNextTaskAllowedRetries(Runner::TASK_RETRY_ALWAYS)
                    ->setNextTaskReturnValue('success')
                    ->runTask();
@@ -365,7 +365,7 @@ class RunnerTest extends BaseTest
 
     public function testMultipleTaskRetriesWithSuccess()
     {
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $result = $this->setNextTasksAllowedRetries(2, Runner::TASK_RETRY_ALWAYS)
                    ->setNextTaskReturnValue('success')
                    ->runTask();
@@ -380,7 +380,7 @@ class RunnerTest extends BaseTest
     {
         $this->expectException(ServiceException::class);
 
-        $this->setRetryConfig(array('retries' => 5));
+        $this->setRetryConfig(['retries' => 5]);
         $this->setNextTasksAllowedRetries($limit + 1, $limit)
          ->runTask();
     }
@@ -396,20 +396,20 @@ class RunnerTest extends BaseTest
 
         $this->assertTaskTimeGreaterThanOrEqual(
             $minTime,
-            array($this, 'runTask'),
+            [$this, 'runTask'],
             $config['initial_delay'] / 10
         );
     }
 
     public function testTaskWithManualRetries()
     {
-        $this->setRetryConfig(array('retries' => 2));
+        $this->setRetryConfig(['retries' => 2]);
         $this->setNextTasksAllowedRetries(2, Runner::TASK_RETRY_ALWAYS);
 
         $task = new Runner(
             $this->retryConfig,
             '',
-            array($this, 'runNextTask')
+            [$this, 'runNextTask']
         );
 
         $this->assertTrue($task->canAttempt());
@@ -432,15 +432,15 @@ class RunnerTest extends BaseTest
    */
     public function timeoutProvider()
     {
-        $config = array('initial_delay' => .001, 'max_delay' => .01);
+        $config = ['initial_delay' => .001, 'max_delay' => .01];
 
-        return array(
-        array(array_merge($config, array('retries' => 1)), .001),
-        array(array_merge($config, array('retries' => 2)), .0015),
-        array(array_merge($config, array('retries' => 3)), .00225),
-        array(array_merge($config, array('retries' => 4)), .00375),
-        array(array_merge($config, array('retries' => 5)), .005625)
-        );
+        return [
+            [array_merge($config, ['retries' => 1]), .001],
+            [array_merge($config, ['retries' => 2]), .0015],
+            [array_merge($config, ['retries' => 3]), .00225],
+            [array_merge($config, ['retries' => 4]), .00375],
+            [array_merge($config, ['retries' => 5]), .005625]
+        ];
     }
 
     /**
@@ -450,10 +450,10 @@ class RunnerTest extends BaseTest
    */
     public function customLimitsProvider()
     {
-        return array(
-        array(Runner::TASK_RETRY_NEVER),
-        array(Runner::TASK_RETRY_ONCE),
-        );
+        return [
+            [Runner::TASK_RETRY_NEVER],
+            [Runner::TASK_RETRY_ONCE],
+        ];
     }
 
     /**
@@ -463,13 +463,13 @@ class RunnerTest extends BaseTest
    */
     public function badTaskConfigProvider()
     {
-        return array(
-        array(array('initial_delay' => -1), 'must not be negative'),
-        array(array('max_delay' => 0), 'must be greater than 0'),
-        array(array('factor' => 0), 'must be greater than 0'),
-        array(array('jitter' => 0), 'must be greater than 0'),
-        array(array('retries' => -1), 'must not be negative')
-        );
+        return [
+            [['initial_delay' => -1], 'must not be negative'],
+            [['max_delay' => 0], 'must be greater than 0'],
+            [['factor' => 0], 'must be greater than 0'],
+            [['jitter' => 0], 'must be greater than 0'],
+            [['retries' => -1], 'must not be negative']
+        ];
     }
 
     /**
@@ -479,12 +479,12 @@ class RunnerTest extends BaseTest
    */
     public function defaultRestErrorProvider()
     {
-        return array(
-        array(500),
-        array(503),
-        array(403, '{"error":{"errors":[{"reason":"rateLimitExceeded"}]}}'),
-        array(403, '{"error":{"errors":[{"reason":"userRateLimitExceeded"}]}}'),
-        );
+        return [
+            [500],
+            [503],
+            [403, '{"error":{"errors":[{"reason":"rateLimitExceeded"}]}}'],
+            [403, '{"error":{"errors":[{"reason":"userRateLimitExceeded"}]}}'],
+        ];
     }
 
     /**
@@ -494,13 +494,13 @@ class RunnerTest extends BaseTest
    */
     public function defaultCurlErrorProvider()
     {
-        return array(
-        array(6),  // CURLE_COULDNT_RESOLVE_HOST
-        array(7),  // CURLE_COULDNT_CONNECT
-        array(28), // CURLE_OPERATION_TIMEOUTED
-        array(35), // CURLE_SSL_CONNECT_ERROR
-        array(52), // CURLE_GOT_NOTHING
-        );
+        return [
+            [6],  // CURLE_COULDNT_RESOLVE_HOST
+            [7],  // CURLE_COULDNT_CONNECT
+            [28], // CURLE_OPERATION_TIMEOUTED
+            [35], // CURLE_SSL_CONNECT_ERROR
+            [52], // CURLE_GOT_NOTHING
+        ];
     }
 
     /**
@@ -539,13 +539,13 @@ class RunnerTest extends BaseTest
    */
     private function setRetryConfig(array $config)
     {
-        $config += array(
-        'initial_delay' => .0001,
-        'max_delay' => .001,
-        'factor' => 2,
-        'jitter' => .5,
-        'retries' => 1
-        );
+        $config += [
+            'initial_delay' => .0001,
+            'max_delay' => .001,
+            'factor' => 2,
+            'jitter' => .5,
+            'retries' => 1
+        ];
         $this->retryConfig = $config;
     }
 
@@ -568,7 +568,7 @@ class RunnerTest extends BaseTest
         $count,
         $code = '200',
         $body = '{}',
-        array $headers = array()
+        array $headers = []
     ) {
         while ($count-- > 0) {
             $this->setNextResponse($code, $body, $headers);
@@ -589,13 +589,13 @@ class RunnerTest extends BaseTest
     private function setNextResponse(
         $code = '200',
         $body = '{}',
-        array $headers = array()
+        array $headers = []
     ) {
-        $this->mockedCalls[$this->mockedCallsCount++] = array(
-        'code' => (string) $code,
-        'headers' => $headers,
-        'body' => is_string($body) ? $body : json_encode($body)
-        );
+        $this->mockedCalls[$this->mockedCallsCount++] = [
+            'code' => (string) $code,
+            'headers' => $headers,
+            'body' => is_string($body) ? $body : json_encode($body)
+        ];
 
         return $this;
     }
@@ -632,7 +632,7 @@ class RunnerTest extends BaseTest
             $message,
             $code,
             null,
-            array()
+            []
         );
 
         return $this;
@@ -744,7 +744,7 @@ class RunnerTest extends BaseTest
         $task = new Runner(
             $this->retryConfig,
             '',
-            array($this, 'runNextTask')
+            [$this, 'runNextTask']
         );
 
         if (null !== $this->retryMap) {
@@ -754,7 +754,7 @@ class RunnerTest extends BaseTest
         $exception = $this->prophesize(ServiceException::class);
 
         $exceptionCount = 0;
-        $exceptionCalls = array();
+        $exceptionCalls = [];
 
         for ($i = 0; $i < $this->mockedCallsCount; $i++) {
             if (is_int($this->mockedCalls[$i])) {

--- a/tests/Google/Utils/UriTemplateTest.php
+++ b/tests/Google/Utils/UriTemplateTest.php
@@ -33,11 +33,11 @@ class UriTemplateTest extends BaseTest
         $urit = new UriTemplate();
         $this->assertEquals(
             "value",
-            $urit->parse("{var}", array("var" => $var))
+            $urit->parse("{var}", ["var" => $var])
         );
         $this->assertEquals(
             "Hello%20World%21",
-            $urit->parse("{hello}", array("hello" => $hello))
+            $urit->parse("{hello}", ["hello" => $hello])
         );
     }
 
@@ -50,27 +50,27 @@ class UriTemplateTest extends BaseTest
         $urit = new UriTemplate();
         $this->assertEquals(
             "value",
-            $urit->parse("{+var}", array("var" => $var))
+            $urit->parse("{+var}", ["var" => $var])
         );
         $this->assertEquals(
             "Hello%20World!",
-            $urit->parse("{+hello}", array("hello" => $hello))
+            $urit->parse("{+hello}", ["hello" => $hello])
         );
         $this->assertEquals(
             "/foo/bar/here",
-            $urit->parse("{+path}/here", array("path" => $path))
+            $urit->parse("{+path}/here", ["path" => $path])
         );
         $this->assertEquals(
             "here?ref=/foo/bar",
-            $urit->parse("here?ref={+path}", array("path" => $path))
+            $urit->parse("here?ref={+path}", ["path" => $path])
         );
         $this->assertEquals(
             "X#value",
-            $urit->parse("X{#var}", array("var" => $var))
+            $urit->parse("X{#var}", ["var" => $var])
         );
         $this->assertEquals(
             "X#Hello%20World!",
-            $urit->parse("X{#hello}", array("hello" => $hello))
+            $urit->parse("X{#hello}", ["hello" => $hello])
         );
     }
 
@@ -86,97 +86,97 @@ class UriTemplateTest extends BaseTest
         $urit = new UriTemplate();
         $this->assertEquals(
             "map?1024,768",
-            $urit->parse("map?{x,y}", array("x" => $x, "y" => $y))
+            $urit->parse("map?{x,y}", ["x" => $x, "y" => $y])
         );
         $this->assertEquals(
             "1024,Hello%20World%21,768",
-            $urit->parse("{x,hello,y}", array("x" => $x, "y" => $y, "hello" => $hello))
+            $urit->parse("{x,hello,y}", ["x" => $x, "y" => $y, "hello" => $hello])
         );
 
         $this->assertEquals(
             "1024,Hello%20World!,768",
-            $urit->parse("{+x,hello,y}", array("x" => $x, "y" => $y, "hello" => $hello))
+            $urit->parse("{+x,hello,y}", ["x" => $x, "y" => $y, "hello" => $hello])
         );
         $this->assertEquals(
             "/foo/bar,1024/here",
-            $urit->parse("{+path,x}/here", array("x" => $x, "path" => $path))
+            $urit->parse("{+path,x}/here", ["x" => $x, "path" => $path])
         );
 
         $this->assertEquals(
             "#1024,Hello%20World!,768",
-            $urit->parse("{#x,hello,y}", array("x" => $x, "y" => $y, "hello" => $hello))
+            $urit->parse("{#x,hello,y}", ["x" => $x, "y" => $y, "hello" => $hello])
         );
         $this->assertEquals(
             "#/foo/bar,1024/here",
-            $urit->parse("{#path,x}/here", array("x" => $x, "path" => $path))
+            $urit->parse("{#path,x}/here", ["x" => $x, "path" => $path])
         );
 
         $this->assertEquals(
             "X.value",
-            $urit->parse("X{.var}", array("var" => $var))
+            $urit->parse("X{.var}", ["var" => $var])
         );
         $this->assertEquals(
             "X.1024.768",
-            $urit->parse("X{.x,y}", array("x" => $x, "y" => $y))
+            $urit->parse("X{.x,y}", ["x" => $x, "y" => $y])
         );
 
         $this->assertEquals(
             "X.value",
-            $urit->parse("X{.var}", array("var" => $var))
+            $urit->parse("X{.var}", ["var" => $var])
         );
         $this->assertEquals(
             "X.1024.768",
-            $urit->parse("X{.x,y}", array("x" => $x, "y" => $y))
+            $urit->parse("X{.x,y}", ["x" => $x, "y" => $y])
         );
 
         $this->assertEquals(
             "/value",
-            $urit->parse("{/var}", array("var" => $var))
+            $urit->parse("{/var}", ["var" => $var])
         );
         $this->assertEquals(
             "/value/1024/here",
-            $urit->parse("{/var,x}/here", array("x" => $x, "var" => $var))
+            $urit->parse("{/var,x}/here", ["x" => $x, "var" => $var])
         );
 
         $this->assertEquals(
             ";x=1024;y=768",
-            $urit->parse("{;x,y}", array("x" => $x, "y" => $y))
+            $urit->parse("{;x,y}", ["x" => $x, "y" => $y])
         );
         $this->assertEquals(
             ";x=1024;y=768;empty",
-            $urit->parse("{;x,y,empty}", array("x" => $x, "y" => $y, "empty" => $empty))
+            $urit->parse("{;x,y,empty}", ["x" => $x, "y" => $y, "empty" => $empty])
         );
 
         $this->assertEquals(
             "?x=1024&y=768",
-            $urit->parse("{?x,y}", array("x" => $x, "y" => $y))
+            $urit->parse("{?x,y}", ["x" => $x, "y" => $y])
         );
         $this->assertEquals(
             "?x=1024&y=768&empty=",
-            $urit->parse("{?x,y,empty}", array("x" => $x, "y" => $y, "empty" => $empty))
+            $urit->parse("{?x,y,empty}", ["x" => $x, "y" => $y, "empty" => $empty])
         );
 
         $this->assertEquals(
             "?fixed=yes&x=1024",
-            $urit->parse("?fixed=yes{&x}", array("x" => $x, "y" => $y))
+            $urit->parse("?fixed=yes{&x}", ["x" => $x, "y" => $y])
         );
         $this->assertEquals(
             "&x=1024&y=768&empty=",
-            $urit->parse("{&x,y,empty}", array("x" => $x, "y" => $y, "empty" => $empty))
+            $urit->parse("{&x,y,empty}", ["x" => $x, "y" => $y, "empty" => $empty])
         );
     }
 
     public function testLevelFour()
     {
-        $values = array(
+        $values = [
             'var'   => "value",
             'hello' => "Hello World!",
             'path'  => "/foo/bar",
-            'list'  => array("red", "green", "blue"),
-            'keys'  => array("semi" => ";", "dot" => ".", "comma" => ","),
-        );
+            'list'  => ["red", "green", "blue"],
+            'keys'  => ["semi" => ";", "dot" => ".", "comma" => ","],
+        ];
 
-        $tests = array(
+        $tests = [
             "{var:3}" => "val",
             "{var:30}" => "value",
             "{list}" => "red,green,blue",
@@ -221,7 +221,7 @@ class UriTemplateTest extends BaseTest
             "{&keys*}" => "&semi=%3B&dot=.&comma=%2C",
             "find{?list*}" => "find?list=red&list=green&list=blue",
             "www{.list*}" => "www.red.green.blue"
-        );
+        ];
 
         $urit = new UriTemplate();
 
@@ -239,15 +239,15 @@ class UriTemplateTest extends BaseTest
             "http://www.google.com/Hello%20World!?var=value",
             $urit->parse(
                 "http://www.google.com/{+hello}{?var}",
-                array("var" => $var, "hello" => $hello)
+                ["var" => $var, "hello" => $hello]
             )
         );
-        $params = array(
+        $params = [
             "playerId" => "me",
             "leaderboardId" => "CgkIhcG1jYEbEAIQAw",
             "timeSpan" => "ALL_TIME",
             "other" => "irrelevant"
-        );
+        ];
         $this->assertEquals(
             "players/me/leaderboards/CgkIhcG1jYEbEAIQAw/scores/ALL_TIME",
             $urit->parse(


### PR DESCRIPTION
Continuing to improve and modify our code standard for this repo:

 - use short-array syntax
 - remove unused imports
 - order all import statements
 - use `elseif` instead of `else if`
 - require `()` for new classes
 - fix some whitespace that was missed before