### PR TITLE
fix: add missing public var used by subclasses

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -26,6 +26,7 @@ class Service
     public $rootUrl;
     public $version;
     public $servicePath;
+    public $serviceName;
     public $availableScopes;
     public $resource;
     private $client;


### PR DESCRIPTION
The classes generated in `google/apiclient-services` are setting a local property [$serviceName](https://github.com/googleapis/google-api-php-client-services/blob/main/src/Storage.php#L77) which isn't actually defined anywhere. 