### PR TITLE
fix: PHP 8.1 compatibility for Task\Runner::backOff

### DIFF
--- a/src/Task/Runner.php
+++ b/src/Task/Runner.php
@@ -236,7 +236,7 @@ class Runner
     {
         $delay = $this->getDelay();
 
-        usleep($delay * 1000000);
+        usleep((int) ($delay * 1000000));
     }
 
     /**


### PR DESCRIPTION
Fixes the PHP 8.1 error "Implicit conversion from float ... to int loses precision". The usleep function expects an integer, not a float.