### PR TITLE
Update return type of `Exception::getErrors()` to its correct structure

### DIFF
--- a/src/Service/Exception.php
+++ b/src/Service/Exception.php
@@ -33,7 +33,7 @@ class Exception extends GoogleException
      * @param string $message
      * @param int $code
      * @param Exception|null $previous
-     * @param array<string,string> $errors List of errors returned in an HTTP
+     * @param array<array<string,string>> $errors List of errors returned in an HTTP
      * response.  Defaults to [].
      */
     public function __construct(
@@ -54,15 +54,17 @@ class Exception extends GoogleException
     /**
      * An example of the possible errors returned.
      *
-     * {
-     *   "domain": "global",
-     *   "reason": "authError",
-     *   "message": "Invalid Credentials",
-     *   "locationType": "header",
-     *   "location": "Authorization",
-     * }
+     * [
+     *   {
+     *     "domain": "global",
+     *     "reason": "authError",
+     *     "message": "Invalid Credentials",
+     *     "locationType": "header",
+     *     "location": "Authorization",
+     *   }
+     * ]
      *
-     * @return array<string,string> List of errors return in an HTTP response or [].
+     * @return array<array<string,string>> List of errors return in an HTTP response or [].
      */
     public function getErrors()
     {


### PR DESCRIPTION
After the latest update static analysis tools hinted on this wrongly typed structure.

The returned structure of `Exception::getErrors()` is an array with a map of keys and values.

The change was introduced here https://github.com/googleapis/google-api-php-client/pull/2252
```
[
    {
        "domain": "global",
        "reason": "authError",
        "message": "Invalid Credentials",
        "locationType": "header",
        "location": "Authorization"
    }
]
```