### PR TITLE
Add http options to allow timeout

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -115,6 +115,7 @@ class Client
             // Don't change these unless you're working against a special development
             // or testing environment.
             'base_path' => self::API_BASE_PATH,
+            'http_options' => null,
 
             // https://developers.google.com/console
             'client_id' => '',
@@ -1209,6 +1210,10 @@ class Client
             ];
         } else {
             throw new LogicException('Could not find supported version of Guzzle.');
+        }
+
+        if (!is_null($this->config['http_options'])) {
+            $options = array_merge($options, $this->config['http_options']);
         }
 
         return new GuzzleClient($options);


### PR DESCRIPTION
As mentioned here: https://github.com/googleapis/google-api-php-client/issues/1767

There is no simple way to set a `timeout` or any other options to the guzzle client. 

The suggestion from @jdpedrie in above issue is not optimal since you lose the default options set by this package. With this change you can easily do:

```php
$client = new Google_Client([
  'http_options' => [
     'timeout' => 5
  ]
]);
```