### PR TITLE
fix (style): lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The Google API Client Library enables you to work with Google APIs such as Gmail, Drive or YouTube on your server.
 
-These client libraries are officially supported by Google.  However, the libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues but will not add any new features.
+These client libraries are officially supported by Google. However, the libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues but will not add any new features.
 
 ## Google Cloud Platform
 

--- a/examples/batch.php
+++ b/examples/batch.php
@@ -90,4 +90,4 @@ $results = $batch->execute();
   <br />
 <?php endforeach ?>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/idtoken.php
+++ b/examples/idtoken.php
@@ -106,4 +106,4 @@ if ($client->getAccessToken()) {
 <?php endif ?>
 </div>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/large-file-download.php
+++ b/examples/large-file-download.php
@@ -146,4 +146,4 @@ if ($client->getAccessToken()) {
 <?php endif ?>
 </div>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/large-file-upload.php
+++ b/examples/large-file-upload.php
@@ -167,4 +167,4 @@ function readVideoChunk($handle, $chunkSize)
 <?php endif ?>
 </div>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/multi-api.php
+++ b/examples/multi-api.php
@@ -117,4 +117,4 @@ if ($client->getAccessToken()) {
   </div>
 </div>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/simple-file-upload.php
+++ b/examples/simple-file-upload.php
@@ -132,4 +132,4 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && $client->getAccessToken()) {
 <?php endif ?>
 </div>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);

--- a/examples/simple-query.php
+++ b/examples/simple-query.php
@@ -87,4 +87,4 @@ $resultsDeferred = $client->execute($request);
   <br />
 <?php endforeach ?>
 
-<?= pageFooter(__FILE__)
+<?= pageFooter(__FILE__);


### PR DESCRIPTION
fixing lint errors due to non closure of PHP tags

Fixes: https://github.com/googleapis/google-api-php-client/issues/2316


I ran `php -S localhost:8080 -t examples/` and the example pages load correctly on browser, without any errors on server.

<img width="1040" alt="Screenshot 2022-09-15 at 14 56 37" src="https://user-images.githubusercontent.com/7369612/190368644-45b76268-ab86-4b95-b919-4fee8c0d8507.png">

<img width="947" alt="Screenshot 2022-09-15 at 14 56 53" src="https://user-images.githubusercontent.com/7369612/190368672-20bc2907-d839-45ee-b5c7-1d9ac92e4dc7.png">

