### PR TITLE
chore: change the prefix to `https://`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Client library for Google APIs",
     "keywords": ["google"],
-    "homepage": "http://developers.google.com/api-client-library/php",
+    "homepage": "https://developers.google.com/api-client-library/php",
     "license": "Apache-2.0",
     "require": {
         "php": "^5.6|^7.0|^8.0",


### PR DESCRIPTION
Change the link prefix of the [`homepage`](https://github.com/googleapis/google-api-php-client/blob/88cc63c38b0cf88629f66fdf8ba6006f6c6d5a2c/composer.json#L6) property in the `composer.json` file