### PR TITLE
feat: make auth http client config extends from default client config

### DIFF
--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -105,11 +105,6 @@ class Guzzle6AuthHandler
 
     private function createAuthHttp(ClientInterface $http)
     {
-        return new Client([
-            'base_uri' => $http->getConfig('base_uri'),
-            'http_errors' => true,
-            'verify' => $http->getConfig('verify'),
-            'proxy' => $http->getConfig('proxy'),
-        ]);
+        return new Client(['http_errors' => true] + $http->getConfig());
     }
 }

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -997,14 +997,8 @@ class ClientTest extends BaseTest
 
         $httpClient = $this->prophesize('GuzzleHttp\ClientInterface');
         $httpClient->getConfig()
-            ->shouldBeCalledOnce()
+            ->shouldBeCalled()
             ->willReturn(['handler' => $handler->reveal()]);
-        $httpClient->getConfig('base_uri')
-            ->shouldBeCalledOnce();
-        $httpClient->getConfig('verify')
-            ->shouldBeCalledOnce();
-        $httpClient->getConfig('proxy')
-            ->shouldBeCalledOnce();
         $httpClient->send(Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 


### PR DESCRIPTION
Hi there :wave: 

Here is the patch following this issue https://github.com/googleapis/google-api-php-client/issues/2345
