### PR TITLE
chore: require firebase/php-jwt v6 to force fix for key/algorithm type confusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.6|^7.0|^8.0",
         "google/auth": "^1.10",
         "google/apiclient-services": "~0.200",
-        "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0||~6.0",
+        "firebase/php-jwt": "^6.0",
         "monolog/monolog": "^1.17||^2.0||^3.0",
         "phpseclib/phpseclib": "~2.0||^3.0.2",
         "guzzlehttp/guzzle": "~5.3.3||~6.0||~7.0",


### PR DESCRIPTION
Possibility of Reintroducing HS256/RSA256 Type Confusion (CVE-2021-46743) 
https://github.com/firebase/php-jwt/issues/351
https://github.com/advisories/GHSA-8xf4-w7qw-pjjw