### PR TITLE
fix: ensure class_exists is not called with null

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -293,7 +293,7 @@ class Model implements \ArrayAccess
         $keyType = $key . "Type";
 
         // ensure keyType is a valid class
-        if (property_exists($this, $keyType) && class_exists($this->$keyType)) {
+        if (property_exists($this, $keyType) && $this->$keyType !== null && class_exists($this->$keyType)) {
             return $this->$keyType;
         }
     }


### PR DESCRIPTION
In the `keyType()` function in `Model.php` we were calling `class_exists()` to find out if a class existed. However, in some cases the value that we were checking could be null. Since PHP 8.1 a deprecation warning is thrown. In this PR we check that the value that we are passing is not null before calling `class_exists()`, thus removing the deprecation

Fixes #2372