### PR TITLE
Fix: Uncaught Runtime Exception: Unable to read from stream

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1205,6 +1205,7 @@ class Client
             $options = [
                 'base_uri' => $this->config['base_path'],
                 'http_errors' => false,
+                'stream' => TRUE
             ];
         } else {
             throw new LogicException('Could not find supported version of Guzzle.');


### PR DESCRIPTION
```
[Fri Mar 17 20:23:17.946922 2023] [php:error] [pid 1703] [client 172.17.0.1:53962] PHP Fatal error:  Uncaught RuntimeException: Unable to read from stream in /var/www/html/vendor/guzzlehttp/psr7/src/Stream.php:237
Stack trace:
#0 /var/www/html/vendor/guzzlehttp/psr7/src/Utils.php(53): GuzzleHttp\\Psr7\\Stream->read()
#1 /var/www/html/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php(210): GuzzleHttp\\Psr7\\Utils::copyToStream()
#2 /var/www/html/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php(140): GuzzleHttp\\Handler\\StreamHandler->drain()
#3 /var/www/html/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php(56): GuzzleHttp\\Handler\\StreamHandler->createResponse()
#4 /var/www/html/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php(35): GuzzleHttp\\Handler\\StreamHandler->__invoke()
#5 /var/www/html/vendor/guzzlehttp/guzzle/src/Middleware.php(31): GuzzleHttp\\PrepareBodyMiddleware->__invoke()
#6 /var/www/html/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php(71): GuzzleHttp\\Middleware::GuzzleHttp\\{closure}()
#7 /var/www/html/vendor/guzzlehttp/guzzle/src/Middleware.php(61): GuzzleHttp\\RedirectMiddleware->__invoke()
#8 /var/www/html/vendor/guzzlehttp/guzzle/src/HandlerStack.php(75): GuzzleHttp\\Middleware::GuzzleHttp\\{closure}()
#9 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(331): GuzzleHttp\\HandlerStack->__invoke()
#10 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(168): GuzzleHttp\\Client->transfer()
#11 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(187): GuzzleHttp\\Client->requestAsync()
#12 /var/www/html/vendor/guzzlehttp/guzzle/src/ClientTrait.php(44): GuzzleHttp\\Client->request()
#13 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(173): GuzzleHttp\\Client->get()
#14 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(201): Google\\AccessToken\\Verify->retrieveCertsFromLocation()
#15 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(105): Google\\AccessToken\\Verify->getFederatedSignOnCerts()
#16 /var/www/html/vendor/google/apiclient/src/Client.php(815): Google\\AccessToken\\Verify->verifyIdToken()
#17 /var/www/html/tryout-google-auth/web/idtoken.php(179): Google\\Client->verifyIdToken()
#18 {main}

Next GuzzleHttp\\Exception\\RequestException: Unable to read from stream in /var/www/html/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:52
Stack trace:
#0 /var/www/html/vendor/guzzlehttp/guzzle/src/Handler/StreamHandler.php(74): GuzzleHttp\\Exception\\RequestException::wrapException()
#1 /var/www/html/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php(35): GuzzleHttp\\Handler\\StreamHandler->__invoke()
#2 /var/www/html/vendor/guzzlehttp/guzzle/src/Middleware.php(31): GuzzleHttp\\PrepareBodyMiddleware->__invoke()
#3 /var/www/html/vendor/guzzlehttp/guzzle/src/RedirectMiddleware.php(71): GuzzleHttp\\Middleware::GuzzleHttp\\{closure}()
#4 /var/www/html/vendor/guzzlehttp/guzzle/src/Middleware.php(61): GuzzleHttp\\RedirectMiddleware->__invoke()
#5 /var/www/html/vendor/guzzlehttp/guzzle/src/HandlerStack.php(75): GuzzleHttp\\Middleware::GuzzleHttp\\{closure}()
#6 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(331): GuzzleHttp\\HandlerStack->__invoke()
#7 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(168): GuzzleHttp\\Client->transfer()
#8 /var/www/html/vendor/guzzlehttp/guzzle/src/Client.php(187): GuzzleHttp\\Client->requestAsync()
#9 /var/www/html/vendor/guzzlehttp/guzzle/src/ClientTrait.php(44): GuzzleHttp\\Client->request()
#10 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(173): GuzzleHttp\\Client->get()
#11 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(201): Google\\AccessToken\\Verify->retrieveCertsFromLocation()
#12 /var/www/html/vendor/google/apiclient/src/AccessToken/Verify.php(105): Google\\AccessToken\\Verify->getFederatedSignOnCerts()
#13 /var/www/html/vendor/google/apiclient/src/Client.php(815): Google\\AccessToken\\Verify->verifyIdToken()
#14 /var/www/html/tryout-google-auth/web/idtoken.php(179): Google\\Client->verifyIdToken()
#15 {main}
  thrown in /var/www/html/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php on line 52
```