### PR TITLE
chore: docs for accessing granted scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,17 @@ $client->setHttpClient($httpClient);
 
 Other Guzzle features such as [Handlers and Middleware](http://docs.guzzlephp.org/en/stable/handlers-and-middleware.html) offer even more control.
 
+### Accessing Granted Scopes
+
+If you're using OAuth2 3LO (e.g. you're a client requesting credentials from a
+3rd party, such as in the [simple file upload example][examples/simple-file-upload.php]),
+you can see which scopes were granted by calling `getGrantedScope` on the OAuth2 object:
+
+```php
+// Comma-separated string of granted scopes if it exists, otherwise null.
+$client->getOAuth2Service()->getGrantedScope();
+```
+
 ### Service Specific Examples ###
 
 YouTube: https://github.com/youtube/api-samples/tree/master/php

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Other Guzzle features such as [Handlers and Middleware](http://docs.guzzlephp.or
 ### Accessing Granted Scopes
 
 If you're using OAuth2 3LO (e.g. you're a client requesting credentials from a
-3rd party, such as in the [simple file upload example][examples/simple-file-upload.php]),
+3rd party, such as in the [simple file upload example](examples/simple-file-upload.php),
 you can see which scopes were granted by calling `getGrantedScope` on the OAuth2 object:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^5.6|^7.0|^8.0",
-        "google/auth": "^1.10",
+        "google/auth": "^1.26",
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0||~6.0",
         "monolog/monolog": "^1.17||^2.0||^3.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^5.6|^7.0|^8.0",
-        "google/auth": "^1.26",
+        "google/auth": "^1.10",
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0||~6.0",
         "monolog/monolog": "^1.17||^2.0||^3.0",


### PR DESCRIPTION
Document support for accessing granted scopes, which was added to `google/auth` in https://github.com/googleapis/google-auth-library-php/pull/441