### PR TITLE
feat: add audience parameter to Client::verifyIdToken

### DIFF
--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -91,7 +91,7 @@ class Verify
      * accepted.  By default, the id token must have been issued to this OAuth2 client.
      *
      * @param string $idToken the ID token in JWT format
-     * @param string $audience Optional. The audience to verify against JWt "aud"
+     * @param string $audience Optional. The audience to verify against JWT "aud"
      * @return array|false the token payload, if successful
      */
     public function verifyIdToken($idToken, $audience = null)

--- a/src/Client.php
+++ b/src/Client.php
@@ -443,7 +443,6 @@ class Client
                 $this->config['token_callback']
             );
         }
-
         if ($token = $this->getAccessToken()) {
             $scopes = $this->prepareScopes();
             // add refresh subscriber to request a new token
@@ -794,10 +793,11 @@ class Client
      * @throws LogicException If no token was provided and no token was set using `setAccessToken`.
      * @throws UnexpectedValueException If the token is not a valid JWT.
      * @param string|null $idToken The token (id_token) that should be verified.
+     * @param string|null $audience Optional. The audience to verify against JWT "aud".
      * @return array|false Returns the token payload as an array if the verification was
      * successful, false otherwise.
      */
-    public function verifyIdToken($idToken = null)
+    public function verifyIdToken($idToken = null, string $audience = null)
     {
         $tokenVerifier = new Verify(
             $this->getHttpClient(),
@@ -817,7 +817,7 @@ class Client
 
         return $tokenVerifier->verifyIdToken(
             $idToken,
-            $this->getClientId()
+            $audience ?: $this->getClientId() // use the client ID when no audience is supplied
         );
     }
 

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -79,7 +79,6 @@ class REST
      */
     public static function doExecute(ClientInterface $client, RequestInterface $request, $expectedClass = null)
     {
-        // var_dump($request);exit;
         try {
             $httpHandler = HttpHandlerFactory::build($client);
             $response = $httpHandler($request);

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -79,6 +79,7 @@ class REST
      */
     public static function doExecute(ClientInterface $client, RequestInterface $request, $expectedClass = null)
     {
+        // var_dump($request);exit;
         try {
             $httpHandler = HttpHandlerFactory::build($client);
             $response = $httpHandler($request);


### PR DESCRIPTION
fixes https://github.com/googleapis/google-api-php-client/issues/1900 by allowing an `$audience` parameter that will be used instead of the Client ID configured in the client object.