### PR TITLE
fix: upgrade min phpseclib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",
-        "phpseclib/phpseclib": "^3.0.2",
+        "phpseclib/phpseclib": "^3.0.19",
         "guzzlehttp/guzzle": "~6.5||~7.0",
         "guzzlehttp/psr7": "^1.8.4||^2.2.1"
     },


### PR DESCRIPTION
Upgrade minimum Phpseclib version to `3.0.19` in order to patch security vulnerability GHSA-hm7p-r324-hhf3