### PR TITLE
fix: php 8.3 deprecated get_class method call without argument

### DIFF
--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -55,7 +55,7 @@ class REST
         $runner = new Runner(
             $config,
             sprintf('%s %s', $request->getMethod(), (string) $request->getUri()),
-            [get_class(), 'doExecute'],
+            [self::class, 'doExecute'],
             [$client, $request, $expectedClass]
         );
 


### PR DESCRIPTION
Hi, 

In this PR, I replaced `get_class` with `self:class` due to new deprecations in PHP 8.3, which you can read about it [here](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#:~:text=has%20been%20closed.-,get_class()%20and%20get_parent_class(),-get_class()%20currently)

Since PHP 8.3 is still an RC version, Many things, like upgrading composer packages, need to be done to be compatible with PHP 8.3, but this is a code issue and can be solved right now.

