### PR TITLE
fix: phpseclib security vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",
-        "phpseclib/phpseclib": "^3.0.19",
+        "phpseclib/phpseclib": "^3.0.34",
         "guzzlehttp/guzzle": "~6.5||~7.0",
         "guzzlehttp/psr7": "^1.8.4||^2.2.1"
     },


### PR DESCRIPTION
Upgrades phpseclib to the patched version 3.0.34

https://github.com/advisories/GHSA-jpr7-q523-hx25