### PR TITLE
chore: fix tests for google/auth v1.33

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/psr7": "^1.8.4||^2.2.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.0",
+        "squizlabs/php_codesniffer": "^3.8",
         "symfony/dom-crawler": "~2.1",
         "symfony/css-selector": "~2.1",
         "cache/filesystem-adapter": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4|^8.0",
-        "google/auth": "^1.28",
+        "google/auth": "^1.33",
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -148,11 +148,7 @@
  There MUST be one space between the closing parenthesis and the opening brace
  The structure body MUST be indented once
  The closing brace MUST be on the next line after the body -->
- <rule ref="Squiz.ControlStructures.ControlSignature">
-  <properties>
-   <property name="ignoreComments" value="true"/>
-  </properties>
- </rule>
+ <rule ref="Squiz.ControlStructures.ControlSignature" />
  <rule ref="Squiz.WhiteSpace.ScopeClosingBrace">
    <exclude-pattern>src/aliases\.php</exclude-pattern>
  </rule>

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -851,9 +851,12 @@ class ClientTest extends BaseTest
             ->willReturn('cache-key');
 
         // Ensure the access token provided by our credentials loader is used
-        $credentials->fetchAuthToken(Argument::any())
+        $credentials->updateMetadata([], null, Argument::any())
             ->shouldBeCalledOnce()
-            ->willReturn(['access_token' => 'abc']);
+            ->willReturn(['authorization' => 'Bearer abc']);
+        $credentials->getLastReceivedToken()
+            ->shouldBeCalledTimes(2)
+            ->willReturn(null);
 
         $client = new Client(['credentials' => $credentials->reveal()]);
 


### PR DESCRIPTION
Fixes the tests for refactoring that happened in `google/auth:v1.33.0`.

See https://github.com/googleapis/google-auth-library-php/pull/492