### PR TITLE
fix: batch requesting RequestInterface

### DIFF
--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -66,7 +66,7 @@ class Batch
         $this->batchPath = $batchPath ?: self::BATCH_PATH;
     }
 
-    public function add(RequestInterface $request, $key = false)
+    public function add($request, $key = false)
     {
         if (false == $key) {
             $key = mt_rand();


### PR DESCRIPTION
This error causing the batch add requesting an  `Psr\Http\Message\RequestInterface;`. But this is an error.