### PR TITLE
feat: add universe domain support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/css-selector": "~2.1",
         "cache/filesystem-adapter": "^1.1",
         "phpcompatibility/php-compatibility": "^9.2",
-        "composer/composer": "^1.10.22",
+        "composer/composer": "^1.10.23",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4|^8.0",
-        "google/auth": "dev-add-universe-domain-cache as 1.39",
+        "google/auth": "^1.37",
         "google/apiclient-services": "dev-universe-domain as 0.340",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "google/auth": "dev-add-universe-domain-cache as 1.39",
-        "google/apiclient-services": "~0.200",
+        "google/apiclient-services": "dev-universe-domain as 0.340",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",
         "phpseclib/phpseclib": "^3.0.34",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "google/auth": "^1.37",
-        "google/apiclient-services": "dev-universe-domain as 0.340",
+        "google/apiclient-services": "~0.350",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",
         "phpseclib/phpseclib": "^3.0.34",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^7.4|^8.0",
-        "google/auth": "^1.33",
+        "google/auth": "dev-add-universe-domain-cache as 1.39",
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -136,6 +136,10 @@ class Client
 
             // Simple API access key, also from the API console. Ensure you get
             // a Server key, and not a Browser key.
+            // **NOTE:** The universe domain is assumed to be "googleapis.com" unless
+            // explicitly set. When setting an API ley directly via this option, there
+            // is no way to verify the universe domain. Be sure to set the
+            // "universe_domain" option if "googleapis.com" is not intended.
             'developer_key' => '',
 
             // For use with Google Cloud Platform
@@ -179,7 +183,8 @@ class Client
             // from certain APIs.
             'api_format_v2' => false,
 
-            // Setting the universe domain will change the
+            // Setting the universe domain will change the default rootUrl of the service.
+            // The universe domain is assumed to be "googleapis.com" if not set explicitly.
             'universe_domain' => GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
         ], $config);
 
@@ -510,6 +515,11 @@ class Client
      * token by calling `$client->getCache()->clear()`. (Use caution in this case,
      * as calling `clear()` will remove all cache items, including any items not
      * related to Google API PHP Client.)
+     *
+     * **NOTE:** The universe domain is assumed to be "googleapis.com" unless
+     * explicitly set. When setting an access token directly via this method, there
+     * is no way to verify the universe domain. Be sure to set the "universe_domain"
+     * option if "googleapis.com" is not intended.
      *
      * @param string|array $token
      * @throws InvalidArgumentException

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,7 +171,8 @@ class Client
      *           from certain APIs.
      *     @type string $universe_domain
      *           Setting the universe domain will change the default rootUrl of the service.
-     *           The universe domain is assumed to be "googleapis.com" if not set explicitly.
+     *           If not set explicitly, the universe domain will be "googleapis.com", or the
+     *           value provided in the "GOOGLE_CLOUD_UNIVERSE_DOMAIN" environment variable.
      *  }
      */
     public function __construct(array $config = [])
@@ -205,8 +206,9 @@ class Client
             'cache_config' => [],
             'token_callback' => null,
             'jwt' => null,
-            'api_format_v2' => false
-            'universe_domain' => GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
+            'api_format_v2' => false,
+            'universe_domain' => getenv('GOOGLE_CLOUD_UNIVERSE_DOMAIN')
+                ?: GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
         ], $config);
 
         if (!is_null($this->config['credentials'])) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,8 +171,8 @@ class Client
      *           from certain APIs.
      *     @type string $universe_domain
      *           Setting the universe domain will change the default rootUrl of the service.
-     *           If not set explicitly, the universe domain will be "googleapis.com", or the
-     *           value provided in the "GOOGLE_CLOUD_UNIVERSE_DOMAIN" environment variable.
+     *           If not set explicitly, the universe domain will be the value provided in the
+     *.          "GOOGLE_CLOUD_UNIVERSE_DOMAIN" environment variable, or "googleapis.com".
      *  }
      */
     public function __construct(array $config = [])

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -62,7 +62,12 @@ class Batch
     ) {
         $this->client = $client;
         $this->boundary = $boundary ?: mt_rand();
-        $this->rootUrl = rtrim($rootUrl ?: $this->client->getConfig('base_path'), '/');
+        $rootUrl = rtrim($rootUrl ?: $this->client->getConfig('base_path'), '/');
+        $this->rootUrl = str_replace(
+            'UNIVERSE_DOMAIN',
+            $this->client->getUniverseDomain(),
+            $rootUrl
+        );
         $this->batchPath = $batchPath ?: self::BATCH_PATH;
     }
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -23,7 +23,11 @@ use TypeError;
 class Service
 {
     public $batchPath;
+    /**
+     * @deprecated use $rootUrlTemplate instead
+     */
     public $rootUrl;
+    public $rootUrlTemplate;
     public $version;
     public $servicePath;
     public $serviceName;

--- a/src/Service.php
+++ b/src/Service.php
@@ -24,7 +24,7 @@ class Service
 {
     public $batchPath;
     /**
-     * @deprecated use $rootUrlTemplate instead
+     * Only used in getBatch
      */
     public $rootUrl;
     public $rootUrlTemplate;

--- a/src/Service.php
+++ b/src/Service.php
@@ -69,7 +69,7 @@ class Service
         return new Batch(
             $this->client,
             false,
-            $this->rootUrl,
+            $this->rootUrlTemplate ?? $this->rootUrl,
             $this->batchPath
         );
     }

--- a/src/Service/Resource.php
+++ b/src/Service/Resource.php
@@ -45,8 +45,8 @@ class Resource
         'prettyPrint' => ['type' => 'string', 'location' => 'query'],
     ];
 
-    /** @var string $rootUrl */
-    private $rootUrl;
+    /** @var string $rootUrlTemplate */
+    private $rootUrlTemplate;
 
     /** @var \Google\Client $client */
     private $client;
@@ -65,7 +65,7 @@ class Resource
 
     public function __construct($service, $serviceName, $resourceName, $resource)
     {
-        $this->rootUrl = $service->rootUrl;
+        $this->rootUrlTemplate = $service->rootUrlTemplate ?? $service->rootUrl;
         $this->client = $service->getClient();
         $this->servicePath = $service->servicePath;
         $this->serviceName = $serviceName;
@@ -268,12 +268,14 @@ class Resource
             $requestUrl = $this->servicePath . $restPath;
         }
 
-        // code for leading slash
-        if ($this->rootUrl) {
-            if ('/' !== substr($this->rootUrl, -1) && '/' !== substr($requestUrl, 0, 1)) {
+        if ($this->rootUrlTemplate) {
+            // code for universe domain
+            $rootUrl = str_replace('UNIVERSE_DOMAIN', $this->client->getUniverseDomain(), $this->rootUrlTemplate);
+            // code for leading slash
+            if ('/' !== substr($rootUrl, -1) && '/' !== substr($requestUrl, 0, 1)) {
                 $requestUrl = '/' . $requestUrl;
             }
-            $requestUrl = $this->rootUrl . $requestUrl;
+            $requestUrl = $rootUrl . $requestUrl;
         }
         $uriTemplateVars = [];
         $queryVars = [];

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -35,10 +35,11 @@ use Prophecy\Argument;
 
 class TestService extends \Google\Service
 {
-    public function __construct(Client $client)
+    public function __construct(Client $client, $rootUrl = null)
     {
         parent::__construct($client);
-        $this->rootUrl = "https://test.example.com";
+        $this->rootUrl = $rootUrl ?: "https://test.example.com";
+        $this->rootUrlTemplate = $rootUrl ?: "https://test.UNIVERSE_DOMAIN";
         $this->servicePath = "";
         $this->version = "v1beta1";
         $this->serviceName = "test";
@@ -59,7 +60,7 @@ class ResourceTest extends BaseTest
         $this->client->getLogger()->willReturn($logger->reveal());
         $this->client->shouldDefer()->willReturn(true);
         $this->client->getHttpClient()->willReturn(new GuzzleClient());
-        $this->client->getUniverseDomain()->willReturn('googleapis.com');
+        $this->client->getUniverseDomain()->willReturn('example.com');
 
         $this->service = new TestService($this->client->reveal());
     }
@@ -107,6 +108,37 @@ class ResourceTest extends BaseTest
         $this->assertFalse($request->hasHeader('Content-Type'));
     }
 
+    public function testCallWithUniverseDomainTemplate()
+    {
+        $client = $this->prophesize(Client::class);
+        $logger = $this->prophesize("Monolog\Logger");
+        $this->client->getLogger()->willReturn($logger->reveal());
+        $this->client->shouldDefer()->willReturn(true);
+        $this->client->getHttpClient()->willReturn(new GuzzleClient());
+        $this->client->getUniverseDomain()->willReturn('example-universe-domain.com');
+
+        $this->service = new TestService($this->client->reveal());
+
+        $resource = new GoogleResource(
+            $this->service,
+            "test",
+            "testResource",
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
+                        "path" => "method/path",
+                        "httpMethod" => "POST",
+                    ]
+                ]
+            ]
+        );
+        $request = $resource->call("testMethod", [[]]);
+        $this->assertEquals("https://test.example-universe-domain.com/method/path", (string) $request->getUri());
+        $this->assertEquals("POST", $request->getMethod());
+        $this->assertFalse($request->hasHeader('Content-Type'));
+    }
+
     public function testCallWithPostBody()
     {
         $resource = new GoogleResource(
@@ -131,9 +163,9 @@ class ResourceTest extends BaseTest
 
     public function testCallServiceDefinedRoot()
     {
-        $this->service->rootUrl = "https://sample.example.com";
+        $service = new TestService($this->client->reveal(), "https://sample.example.com");
         $resource = new GoogleResource(
-            $this->service,
+            $service,
             "test",
             "testResource",
             [

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -59,6 +59,7 @@ class ResourceTest extends BaseTest
         $this->client->getLogger()->willReturn($logger->reveal());
         $this->client->shouldDefer()->willReturn(true);
         $this->client->getHttpClient()->willReturn(new GuzzleClient());
+        $this->client->getUniverseDomain()->willReturn('googleapis.com');
 
         $this->service = new TestService($this->client->reveal());
     }

--- a/tests/Google/ServiceTest.php
+++ b/tests/Google/ServiceTest.php
@@ -80,6 +80,7 @@ class ServiceTest extends TestCase
         )->willReturn($response->reveal());
 
         $client->getConfig('base_path')->willReturn('');
+        $client->getUniverseDomain()->willReturn('');
 
         $model = new TestService($client->reveal());
         $batch = $model->createBatch();


### PR DESCRIPTION
- [x] add tests
- [x] E2E manual test
- [x] Support for `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable
- [x] Support universe domain in `Batch`

See also https://github.com/googleapis/google-api-php-client-services/pull/4675

The following manual test worked using this branch:
```php
$universeDomain = 'MY_UNIVERSE_DOMAIN';
$projectId = 'MY_PROJECT_ID';

$client = new Google\Client([
    'universe_domain' => $universeDomain,
    'scopes' => ['https://www.googleapis.com/auth/cloud-platform'],
]);
$client->useApplicationDefaultCredentials();
$storage = new Google\Service\Storage($client);

$buckets = $storage->buckets->listBuckets($projectId);

foreach ($buckets as $bucket) {
    echo $bucket->name . PHP_EOL;
}
```