### PR TITLE
fix: updates phpseclib because of a security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "google/apiclient-services": "~0.200",
         "firebase/php-jwt": "~6.0",
         "monolog/monolog": "^2.9||^3.0",
-        "phpseclib/phpseclib": "^3.0.34",
+        "phpseclib/phpseclib": "^3.0.36",
         "guzzlehttp/guzzle": "^6.5.8||^7.4.5",
         "guzzlehttp/psr7": "^1.9.1||^2.2.1"
     },


### PR DESCRIPTION
Issue fixed in 3.0.36.

https://github.com/advisories/GHSA-hg35-mp25-qf6h