### PR TITLE
fix: added 'enable_granular_consent' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.15.4](https://github.com/googleapis/google-api-php-client/compare/v2.15.3...v2.15.4) (2024-03-22)
+
+### Features
+
+* Add parameter `enable_granular_consent`
+
 ## [2.15.3](https://github.com/googleapis/google-api-php-client/compare/v2.15.2...v2.15.3) (2024-01-04)
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -142,6 +142,7 @@ class Client
      *     @type string $prompt
      *     @type string $openid
      *     @type bool $include_granted_scopes
+     *     @type bool $enable_granular_consent
      *     @type string $login_hint
      *     @type string $request_visible_actions
      *     @type string $access_type
@@ -187,6 +188,7 @@ class Client
             'prompt' => '',
             'openid.realm' => '',
             'include_granted_scopes' => null,
+            'enable_granular_consent' => null,
             'login_hint' => '',
             'request_visible_actions' => '',
             'access_type' => 'online',
@@ -404,11 +406,17 @@ class Client
             ? null
             : var_export($this->config['include_granted_scopes'], true);
 
+
+        $enableGranularConsent = $this->config['enable_granular_consent'] === null
+            ? null
+            : var_export($this->config['enable_granular_consent'], true);
+
         $params = array_filter([
             'access_type' => $this->config['access_type'],
             'approval_prompt' => $approvalPrompt,
             'hd' => $this->config['hd'],
             'include_granted_scopes' => $includeGrantedScopes,
+            'enable_granular_consent' => $enableGranularConsent,
             'login_hint' => $this->config['login_hint'],
             'openid.realm' => $this->config['openid.realm'],
             'prompt' => $this->config['prompt'],
@@ -783,6 +791,18 @@ class Client
     public function setIncludeGrantedScopes($include)
     {
         $this->config['include_granted_scopes'] = $include;
+    }
+
+    /**
+     * If set to false, more granular Google Account permissions
+     * will be disabled for OAuth client IDs created before 2019.
+     * No effect for newer OAuth client IDs, since more granular
+     * permissions is always enabled for them
+     * @param bool $consent
+     */
+    public function setEnableGranularConsent($consent)
+    {
+        $this->config['enable_granular_consent'] = $consent;
     }
 
     /**

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -156,6 +156,7 @@ class ClientTest extends BaseTest
         $client->setOpenIdRealm('example.com');
         $client->setPrompt('select_account');
         $client->setIncludeGrantedScopes(true);
+        $client->setEnableGranularConsent(false);
         $authUrl = $client->createAuthUrl("http://googleapis.com/scope/foo");
         $expected = "https://accounts.google.com/o/oauth2/v2/auth"
             . "?response_type=code"
@@ -166,6 +167,7 @@ class ClientTest extends BaseTest
             . "&scope=http%3A%2F%2Fgoogleapis.com%2Fscope%2Ffoo"
             . "&hd=example.com"
             . "&include_granted_scopes=true"
+            . "&enable_granular_consent=false"
             . "&openid.realm=example.com"
             . "&prompt=select_account";
 


### PR DESCRIPTION
I have found that in SDK missed parameter `enable_granular_consent`. I've added this parameters to Client's configuration. Please review.