### PR TITLE
feat: Add the protected apiVersion property

### DIFF
--- a/src/Service/Resource.php
+++ b/src/Service/Resource.php
@@ -48,6 +48,9 @@ class Resource
     /** @var string $rootUrl */
     private $rootUrl;
 
+    /** @var string $apiVersion */
+    protected $apiVersion;
+
     /** @var \Google\Client $client */
     private $client;
 
@@ -223,6 +226,13 @@ class Resource
         // rather than using an expected class
         if (isset($parameters['alt']) && $parameters['alt']['value'] == 'media') {
             $expectedClass = null;
+        }
+
+        // If the class which is extending from this one contains
+        // an Api Version, add it to the header
+        if ($this->apiVersion) {
+            $request = $request
+                ->withHeader('X-Goog-Api-Version', $this->apiVersion);
         }
 
         // if the client is marked for deferring, rather than

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -104,6 +104,7 @@ class ResourceTest extends BaseTest
         $this->assertEquals("https://test.example.com/method/path", (string) $request->getUri());
         $this->assertEquals("POST", $request->getMethod());
         $this->assertFalse($request->hasHeader('Content-Type'));
+        $this->assertFalse($request->hasHeader('X-Goog-Api-Version'));
     }
 
     public function testCallWithPostBody()
@@ -441,4 +442,31 @@ class ResourceTest extends BaseTest
             $this->assertEquals($errors, $e->getErrors());
         }
     }
+
+    public function testVersionedResource()
+    {
+        $resource = new VersionedResource(
+            $this->service,
+            "test",
+            "testResource",
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
+                        "path" => "method/path",
+                        "httpMethod" => "POST",
+                    ]
+                ]
+            ]
+        );
+        $request = $resource->call("testMethod", [['postBody' => ['foo' => 'bar']]]);
+        $this->assertEquals("https://test.example.com/method/path", (string) $request->getUri());
+        $this->assertEquals("POST", $request->getMethod());
+        $this->assertTrue($request->hasHeader('X-Goog-Api-Version'));
+    }
+}
+
+class VersionedResource extends GoogleResource
+{
+    protected $apiVersion = 'v1_20240101';
 }

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -463,6 +463,7 @@ class ResourceTest extends BaseTest
         $this->assertEquals("https://test.example.com/method/path", (string) $request->getUri());
         $this->assertEquals("POST", $request->getMethod());
         $this->assertTrue($request->hasHeader('X-Goog-Api-Version'));
+        $this->assertEquals('v1_20240101', $request->getHeaderLine('X-Goog-Api-Version'));
     }
 }
 


### PR DESCRIPTION
Add the protected `apiVersion` property to the `Resource` class to support the new api version header.