### PR TITLE
Add logger to Client constructor too

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -196,6 +196,7 @@ class Client
             'prompt' => '',
             'openid.realm' => '',
             'include_granted_scopes' => null,
+            'logger' => null,
             'login_hint' => '',
             'request_visible_actions' => '',
             'access_type' => 'online',
@@ -241,6 +242,11 @@ class Client
         if (!is_null($this->config['cache'])) {
             $this->setCache($this->config['cache']);
             unset($this->config['cache']);
+        }
+
+        if (!is_null($this->config['logger'])) {
+            $this->setLogger($this->config['logger']);
+            unset($this->config['logger']);
         }
     }
 

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -268,6 +268,16 @@ class ClientTest extends BaseTest
         $this->assertInstanceOf('Monolog\Handler\SyslogHandler', $handler);
     }
 
+    public function testLoggerFromConstructor()
+    {
+        $logger1 = new \Monolog\Logger('unit-test');
+        $client = new Client(['logger' => $logger1]);
+        $logger2 = $client->getLogger();
+        $this->assertInstanceOf('Monolog\Logger', $logger2);
+        $this->assertEquals('unit-test', $logger2->getName());
+        $this->assertSame($logger1, $logger2);
+    }
+
     public function testSettersGetters()
     {
         $client = new Client();
@@ -279,6 +289,7 @@ class ClientTest extends BaseTest
 
         $client->setRedirectUri('localhost');
         $client->setConfig('application_name', 'me');
+        $client->setLogger(new \Monolog\Logger('test'));
 
         $cache = $this->prophesize(CacheItemPoolInterface::class);
         $client->setCache($cache->reveal());


### PR DESCRIPTION
This streamlines configuration on par with all other configuration options.

Added unit-tests.