### PR TITLE
fix: Implicitly marking parameter  as nullable is deprecated

### DIFF
--- a/src/AccessToken/Revoke.php
+++ b/src/AccessToken/Revoke.php
@@ -39,7 +39,7 @@ class Revoke
      * Instantiates the class, but does not initiate the login flow, leaving it
      * to the discretion of the caller.
      */
-    public function __construct(ClientInterface $http = null)
+    public function __construct(?ClientInterface $http = null)
     {
         $this->http = $http;
     }

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -59,7 +59,7 @@ class Verify
 
     /**
      * @var \Firebase\JWT\JWT
-    */
+     */
     public $jwt;
 
     /**
@@ -67,9 +67,9 @@ class Verify
      * to the discretion of the caller.
      */
     public function __construct(
-        ClientInterface $http = null,
-        CacheItemPoolInterface $cache = null,
-        $jwt = null
+        ?ClientInterface $http = null,
+        ?CacheItemPoolInterface $cache = null,
+        ?string $jwt = null
     ) {
         if (null === $http) {
             $http = new Client();
@@ -130,7 +130,7 @@ class Verify
                     return false;
                 }
 
-                return (array) $payload;
+                return (array)$payload;
             } catch (ExpiredException $e) { // @phpstan-ignore-line
                 return false;
             } catch (ExpiredExceptionV3 $e) {
@@ -154,8 +154,8 @@ class Verify
      * Retrieve and cache a certificates file.
      *
      * @param string $url location
-     * @throws \Google\Exception
      * @return array certificates
+     * @throws \Google\Exception
      */
     private function retrieveCertsFromLocation($url)
     {
@@ -163,8 +163,8 @@ class Verify
         if (0 !== strpos($url, 'http')) {
             if (!$file = file_get_contents($url)) {
                 throw new GoogleException(
-                    "Failed to retrieve verification certificates: '" .
-                    $url . "'."
+                    "Failed to retrieve verification certificates: '".
+                    $url."'."
                 );
             }
 
@@ -175,7 +175,7 @@ class Verify
         $response = $this->http->get($url);
 
         if ($response->getStatusCode() == 200) {
-            return json_decode((string) $response->getBody(), true);
+            return json_decode((string)$response->getBody(), true);
         }
         throw new GoogleException(
             sprintf(

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -29,7 +29,7 @@ class Guzzle6AuthHandler
     public function attachCredentials(
         ClientInterface $http,
         CredentialsLoader $credentials,
-        callable $tokenCallback = null
+        ?callable $tokenCallback = null
     ) {
         // use the provided cache
         if ($this->cache) {

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -20,7 +20,7 @@ class Guzzle6AuthHandler
     protected $cache;
     protected $cacheConfig;
 
-    public function __construct(CacheItemPoolInterface $cache = null, array $cacheConfig = [])
+    public function __construct(?CacheItemPoolInterface $cache = null, array $cacheConfig = [])
     {
         $this->cache = $cache;
         $this->cacheConfig = $cacheConfig;
@@ -46,7 +46,7 @@ class Guzzle6AuthHandler
     public function attachCredentialsCache(
         ClientInterface $http,
         FetchAuthTokenCache $credentials,
-        callable $tokenCallback = null
+        ?callable $tokenCallback = null
     ) {
         // if we end up needing to make an HTTP request to retrieve credentials, we
         // can use our existing one, but we need to throw exceptions so the error

--- a/src/Client.php
+++ b/src/Client.php
@@ -321,7 +321,7 @@ class Client
      * @param ClientInterface $authHttp optional.
      * @return array access token
      */
-    public function fetchAccessTokenWithAssertion(ClientInterface $authHttp = null)
+    public function fetchAccessTokenWithAssertion(?ClientInterface $authHttp = null)
     {
         if (!$this->isUsingApplicationDefaultCredentials()) {
             throw new DomainException(
@@ -454,7 +454,7 @@ class Client
      * @param ClientInterface $http the http client object.
      * @return ClientInterface the http client object
      */
-    public function authorize(ClientInterface $http = null)
+    public function authorize(?ClientInterface $http = null)
     {
         $http = $http ?: $this->getHttpClient();
         $authHandler = $this->getAuthHandler();

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -54,7 +54,7 @@ class REST
     ) {
         $runner = new Runner(
             $config,
-            sprintf('%s %s', $request->getMethod(), (string) $request->getUri()),
+            sprintf('%s %s', $request->getMethod(), (string)$request->getUri()),
             [self::class, 'doExecute'],
             [$client, $request, $expectedClass]
         );
@@ -120,7 +120,7 @@ class REST
      */
     public static function decodeHttpResponse(
         ResponseInterface $response,
-        RequestInterface $request = null,
+        ?RequestInterface $request = null,
         $expectedClass = null
     ) {
         $code = $response->getStatusCode();
@@ -128,7 +128,7 @@ class REST
         // retry strategy
         if (intVal($code) >= 400) {
             // if we errored out, it should be safe to grab the response body
-            $body = (string) $response->getBody();
+            $body = (string)$response->getBody();
 
             // Check if we received errors, and add those to the Exception for convenience
             throw new GoogleServiceException($body, $code, null, self::getResponseErrors($body));
@@ -147,17 +147,17 @@ class REST
         return $response;
     }
 
-    private static function decodeBody(ResponseInterface $response, RequestInterface $request = null)
+    private static function decodeBody(ResponseInterface $response, ?RequestInterface $request = null)
     {
         if (self::isAltMedia($request)) {
             // don't decode the body, it's probably a really long string
             return '';
         }
 
-        return (string) $response->getBody();
+        return (string)$response->getBody();
     }
 
-    private static function determineExpectedClass($expectedClass, RequestInterface $request = null)
+    private static function determineExpectedClass($expectedClass, ?RequestInterface $request = null)
     {
         // "false" is used to explicitly prevent an expected class from being returned
         if (false === $expectedClass) {
@@ -184,7 +184,7 @@ class REST
         return null;
     }
 
-    private static function isAltMedia(RequestInterface $request = null)
+    private static function isAltMedia(?RequestInterface $request = null)
     {
         if ($request && $qs = $request->getUri()->getQuery()) {
             parse_str($qs, $query);

--- a/src/Service/Exception.php
+++ b/src/Service/Exception.php
@@ -39,7 +39,7 @@ class Exception extends GoogleException
     public function __construct(
         $message,
         $code = 0,
-        Exception $previous = null,
+        ?Exception $previous = null,
         $errors = []
     ) {
         if (version_compare(PHP_VERSION, '5.3.0') >= 0) {

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -30,7 +30,7 @@ class Composer
      */
     public static function cleanup(
         Event $event,
-        Filesystem $filesystem = null
+        ?Filesystem $filesystem = null
     ) {
         $composer = $event->getComposer();
         $extra = $composer->getPackage()->getExtra();


### PR DESCRIPTION
Fix warning in php 8.4