### PR TITLE
fix: add php 8.4 compatibility to latest 7.4 release

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,8 @@ branchProtectionRules:
     - 'PHP 8.1 Unit Test'
     - 'PHP 8.2 Unit Test'
     - 'PHP 8.3 Unit Test'
-    - 'PHP 8.3 --prefer-lowest Unit Test'
+    - 'PHP 8.4'
+    - 'PHP 8.4 --prefer-lowest Unit Test'
     - 'PHP Style Check'
     - 'cla/google'
   requiredApprovingReviewCount: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
+                php: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
                 composer-flags: [""]
                 include:
                   - php: "7.4"
                     composer-flags: "--prefer-lowest "
-                  - php: "8.3"
+                  - php: "8.4"
                     composer-flags: "--prefer-lowest "
         name: PHP ${{ matrix.php }} ${{ matrix.composer-flags }}Unit Test
         steps:

--- a/src/AccessToken/Revoke.php
+++ b/src/AccessToken/Revoke.php
@@ -39,7 +39,7 @@ class Revoke
      * Instantiates the class, but does not initiate the login flow, leaving it
      * to the discretion of the caller.
      */
-    public function __construct(ClientInterface $http = null)
+    public function __construct(?ClientInterface $http = null)
     {
         $this->http = $http;
     }

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -67,8 +67,8 @@ class Verify
      * to the discretion of the caller.
      */
     public function __construct(
-        ClientInterface $http = null,
-        CacheItemPoolInterface $cache = null,
+        ?ClientInterface $http = null,
+        ?CacheItemPoolInterface $cache = null,
         $jwt = null
     ) {
         if (null === $http) {

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -20,7 +20,7 @@ class Guzzle6AuthHandler
     protected $cache;
     protected $cacheConfig;
 
-    public function __construct(CacheItemPoolInterface $cache = null, array $cacheConfig = [])
+    public function __construct(?CacheItemPoolInterface $cache = null, array $cacheConfig = [])
     {
         $this->cache = $cache;
         $this->cacheConfig = $cacheConfig;
@@ -29,7 +29,7 @@ class Guzzle6AuthHandler
     public function attachCredentials(
         ClientInterface $http,
         CredentialsLoader $credentials,
-        callable $tokenCallback = null
+        ?callable $tokenCallback = null
     ) {
         // use the provided cache
         if ($this->cache) {
@@ -46,7 +46,7 @@ class Guzzle6AuthHandler
     public function attachCredentialsCache(
         ClientInterface $http,
         FetchAuthTokenCache $credentials,
-        callable $tokenCallback = null
+        ?callable $tokenCallback = null
     ) {
         // if we end up needing to make an HTTP request to retrieve credentials, we
         // can use our existing one, but we need to throw exceptions so the error

--- a/src/Client.php
+++ b/src/Client.php
@@ -315,7 +315,7 @@ class Client
      * @param ClientInterface $authHttp optional.
      * @return array access token
      */
-    public function fetchAccessTokenWithAssertion(ClientInterface $authHttp = null)
+    public function fetchAccessTokenWithAssertion(?ClientInterface $authHttp = null)
     {
         if (!$this->isUsingApplicationDefaultCredentials()) {
             throw new DomainException(
@@ -448,7 +448,7 @@ class Client
      * @param ClientInterface $http the http client object.
      * @return ClientInterface the http client object
      */
-    public function authorize(ClientInterface $http = null)
+    public function authorize(?ClientInterface $http = null)
     {
         $http = $http ?: $this->getHttpClient();
         $authHandler = $this->getAuthHandler();

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -120,7 +120,7 @@ class REST
      */
     public static function decodeHttpResponse(
         ResponseInterface $response,
-        RequestInterface $request = null,
+        ?RequestInterface $request = null,
         $expectedClass = null
     ) {
         $code = $response->getStatusCode();
@@ -147,7 +147,7 @@ class REST
         return $response;
     }
 
-    private static function decodeBody(ResponseInterface $response, RequestInterface $request = null)
+    private static function decodeBody(ResponseInterface $response, ?RequestInterface $request = null)
     {
         if (self::isAltMedia($request)) {
             // don't decode the body, it's probably a really long string
@@ -157,7 +157,7 @@ class REST
         return (string) $response->getBody();
     }
 
-    private static function determineExpectedClass($expectedClass, RequestInterface $request = null)
+    private static function determineExpectedClass($expectedClass, ?RequestInterface $request = null)
     {
         // "false" is used to explicitly prevent an expected class from being returned
         if (false === $expectedClass) {
@@ -184,7 +184,7 @@ class REST
         return null;
     }
 
-    private static function isAltMedia(RequestInterface $request = null)
+    private static function isAltMedia(?RequestInterface $request = null)
     {
         if ($request && $qs = $request->getUri()->getQuery()) {
             parse_str($qs, $query);

--- a/src/Service/Exception.php
+++ b/src/Service/Exception.php
@@ -39,7 +39,7 @@ class Exception extends GoogleException
     public function __construct(
         $message,
         $code = 0,
-        Exception $previous = null,
+        ?Exception $previous = null,
         $errors = []
     ) {
         if (version_compare(PHP_VERSION, '5.3.0') >= 0) {

--- a/src/Task/Composer.php
+++ b/src/Task/Composer.php
@@ -30,7 +30,7 @@ class Composer
      */
     public static function cleanup(
         Event $event,
-        Filesystem $filesystem = null
+        ?Filesystem $filesystem = null
     ) {
         $composer = $event->getComposer();
         $extra = $composer->getPackage()->getExtra();

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -698,13 +698,14 @@ class ClientTest extends BaseTest
         $mockUniverseDomainCacheItem->get()
             ->shouldBeCalledTimes(1)
             ->willReturn('googleapis.com');
-
         $mockCache = $this->prophesize(CacheItemPoolInterface::class);
         $mockCache->getItem($prefix . GCECache::GCE_CACHE_KEY)
             ->shouldBeCalledTimes(1)
             ->willReturn($mockCacheItem->reveal());
-        $mockCache->getItem(GCECredentials::cacheKey . 'universe_domain')
-            ->shouldBeCalledTimes(1)
+        // cache key from GCECredentials::getTokenUri() . 'universe_domain'
+        $mockCache->getItem('cc685e3a0717258b6a4cefcb020e96de6bcf904e76fd9fc1647669f42deff9bf') // google/auth < 1.41.0
+            ->willReturn($mockUniverseDomainCacheItem->reveal());
+        $mockCache->getItem(GCECredentials::cacheKey . 'universe_domain') // google/auth >= 1.41.0
             ->willReturn($mockUniverseDomainCacheItem->reveal());
 
         $client = new Client(['cache_config' => $cacheConfig]);


### PR DESCRIPTION
fixes https://github.com/googleapis/google-api-php-client/issues/2640

Adds PHP 8.4 compatibility to the latest PHP 7.4 release (`2.16.0`). This will be tagged as `v2.16.1`