### PR TITLE
Add correct type for $jwt, should be JWT

### DIFF
--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -60,7 +60,7 @@ class Verify
     /**
      * @var \Firebase\JWT\JWT
      */
-    public JWT $jwt;
+    public $jwt;
 
     /**
      * Instantiates the class, but does not initiate the login flow, leaving it

--- a/src/AccessToken/Verify.php
+++ b/src/AccessToken/Verify.php
@@ -60,7 +60,7 @@ class Verify
     /**
      * @var \Firebase\JWT\JWT
      */
-    public $jwt;
+    public JWT $jwt;
 
     /**
      * Instantiates the class, but does not initiate the login flow, leaving it
@@ -69,7 +69,7 @@ class Verify
     public function __construct(
         ?ClientInterface $http = null,
         ?CacheItemPoolInterface $cache = null,
-        ?string $jwt = null
+        ?JWT $jwt = null
     ) {
         if (null === $http) {
             $http = new Client();


### PR DESCRIPTION
For #2641 

This pull request includes changes to the `Verify` class in the `src/AccessToken/Verify.php` file to improve type safety by updating the type hints for the `jwt` property and constructor parameter.

Type safety improvements:

* [`src/AccessToken/Verify.php`](diffhunk://#diff-dbcd1e59f54ffa0425222f56eca976fc29e17bc33c82c559e29703ad397a1d41L63-R63): Changed the type hint of the `jwt` property from `\Firebase\JWT\JWT` to `JWT`.
* [`src/AccessToken/Verify.php`](diffhunk://#diff-dbcd1e59f54ffa0425222f56eca976fc29e17bc33c82c559e29703ad397a1d41L72-R72): Updated the type hint of the `jwt` parameter in the constructor from `?string` to `?JWT`.