### PR TITLE
chore: support firebase/php-jwt version 6.0 and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^8.1",
         "google/auth": "^1.37",
         "google/apiclient-services": "~0.350",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^6.0||^7.0",
         "monolog/monolog": "^2.9||^3.0",
         "phpseclib/phpseclib": "^3.0.36",
         "guzzlehttp/guzzle": "^7.4.5",


### PR DESCRIPTION
Fixes #2695

BEGIN_COMMIT_OVERRIDE
feat: support firebase/php-jwt version 6.0 and 7.0 (#2696)
END_COMMIT_OVERRIDE