### PR TITLE
fix: cast generated header values to strings

### DIFF
--- a/src/Http/MediaFileUpload.php
+++ b/src/Http/MediaFileUpload.php
@@ -297,9 +297,9 @@ class MediaFileUpload
         $body = $this->request->getBody();
         $headers = [
             'content-type' => 'application/json; charset=UTF-8',
-            'content-length' => $body->getSize(),
+            'content-length' => (string) $body->getSize(),
             'x-upload-content-type' => $this->mimeType,
-            'x-upload-content-length' => $this->size,
+            'x-upload-content-length' => (string) $this->size,
             'expect' => '',
         ];
         foreach ($headers as $key => $value) {

--- a/src/Service/Resource.php
+++ b/src/Service/Resource.php
@@ -240,7 +240,7 @@ class Resource
         if ($this->client->shouldDefer()) {
             // @TODO find a better way to do this
             $request = $request
-                ->withHeader('X-Php-Expected-Class', $expectedClass);
+                ->withHeader('X-Php-Expected-Class', (string) $expectedClass);
 
             return $request;
         }

--- a/tests/Google/Http/MediaFileUploadTest.php
+++ b/tests/Google/Http/MediaFileUploadTest.php
@@ -21,11 +21,14 @@
 
 namespace Google\Tests\Http;
 
-use Google\Tests\BaseTest;
+use Google\Client;
 use Google\Http\MediaFileUpload;
 use Google\Service\Drive;
+use Google\Tests\BaseTest;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
 
 class MediaFileUploadTest extends BaseTest
 {
@@ -130,6 +133,23 @@ class MediaFileUploadTest extends BaseTest
         $this->assertArrayHasKey('uploadType', $query);
         $this->assertArrayHasKey('upload_id', $query);
         $this->assertEquals('resumable', $query['uploadType']);
+    }
+
+    public function testGetResumeUriUsesStringHeaderValues()
+    {
+        $client = $this->prophesize(Client::class);
+        $client->execute(Argument::that(function ($request) {
+            $this->assertSame(['2'], $request->getHeader('content-length'));
+            $this->assertSame(['5'], $request->getHeader('x-upload-content-length'));
+
+            return true;
+        }), false)->willReturn(new Response(200, ['location' => 'https://upload.example.com']));
+
+        $request = new Request('POST', 'http://www.example.com', [], '{}');
+        $media = new MediaFileUpload($client->reveal(), $request, 'text/plain', null, true);
+        $media->setFileSize(5);
+
+        $this->assertSame('https://upload.example.com', $media->getResumeUri());
     }
 
     public function testNextChunk()

--- a/tests/Google/Service/ResourceTest.php
+++ b/tests/Google/Service/ResourceTest.php
@@ -106,6 +106,27 @@ class ResourceTest extends BaseTest
         $this->assertEquals("POST", $request->getMethod());
         $this->assertFalse($request->hasHeader('Content-Type'));
         $this->assertFalse($request->hasHeader('X-Goog-Api-Version'));
+        $this->assertSame([''], $request->getHeader('X-Php-Expected-Class'));
+    }
+
+    public function testCallWithExpectedClassHeader()
+    {
+        $resource = new GoogleResource(
+            $this->service,
+            "test",
+            "testResource",
+            [
+                "methods" => [
+                    "testMethod" => [
+                        "parameters" => [],
+                        "path" => "method/path",
+                        "httpMethod" => "POST",
+                    ]
+                ]
+            ]
+        );
+        $request = $resource->call("testMethod", [[]], \stdClass::class);
+        $this->assertSame([\stdClass::class], $request->getHeader('X-Php-Expected-Class'));
     }
 
     public function testCallWithUniverseDomainTemplate()


### PR DESCRIPTION
Hi there. The Guzzle maintainer here again. I am working on the next major version of Guzzle with a focus on security hardening and reducing security-foot guns. As part of those changes, the next major version will disallow non-string header values. I will be triggering deprecations soon on the current major version series, which will start to impact this project, unless it is first modified to stop passing non-string header values. And thus, that is what this PR does.

---

FYI, there is a similar PR open on a sister repo at https://github.com/googleapis/google-cloud-php/pull/9208.