### PR TITLE
chore: upgrade Symfony crawler dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.8",
-        "symfony/dom-crawler": "~2.1",
-        "symfony/css-selector": "~2.1",
+        "symfony/dom-crawler": "^5.4",
+        "symfony/css-selector": "^5.4",
         "cache/filesystem-adapter": "^1.1",
         "phpcompatibility/php-compatibility": "^9.2",
         "composer/composer": "^2.9",


### PR DESCRIPTION
I cross-checked the upstream changes and the usage in this codebase, and it looks like upgrading is as simple as just changing the version constraints.