### PR TITLE
feat: add support for Guzzle 8 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
     "license": "Apache-2.0",
     "require": {
         "php": "^8.1",
-        "google/auth": "^1.37",
+        "google/auth": "^1.53",
         "google/apiclient-services": "~0.350",
         "firebase/php-jwt": "^6.0||^7.0",
         "monolog/monolog": "^2.9||^3.0",
-        "guzzlehttp/guzzle": "^7.4.5",
-        "guzzlehttp/psr7": "^2.6"
+        "guzzlehttp/guzzle": "^7.8.2||^8.0",
+        "guzzlehttp/psr7": "^2.6.3||^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.8",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,7 @@ parameters:
     level: 5
     paths:
     - src
+    excludePaths:
+        # Legacy, unused Guzzle 6 auth handler retained for backwards
+        # compatibility only; it relies on APIs removed in Guzzle 8.
+        - src/AuthHandler/Guzzle6AuthHandler.php

--- a/src/AuthHandler/AuthHandlerFactory.php
+++ b/src/AuthHandler/AuthHandlerFactory.php
@@ -30,17 +30,9 @@ class AuthHandlerFactory
      */
     public static function build($cache = null, array $cacheConfig = [])
     {
-        $guzzleVersion = null;
-        if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
-            $guzzleVersion = ClientInterface::MAJOR_VERSION;
-        } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-            $guzzleVersion = (int) substr(ClientInterface::VERSION, 0, 1);
-        }
-
-        switch ($guzzleVersion) {
-            case 6:
-                return new Guzzle6AuthHandler($cache, $cacheConfig);
+        switch (ClientInterface::MAJOR_VERSION) {
             case 7:
+            case 8:
                 return new Guzzle7AuthHandler($cache, $cacheConfig);
             default:
                 throw new Exception('Version not supported');

--- a/src/AuthHandler/Guzzle6AuthHandler.php
+++ b/src/AuthHandler/Guzzle6AuthHandler.php
@@ -13,7 +13,7 @@ use GuzzleHttp\ClientInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
- * This supports Guzzle 6
+ * @deprecated Guzzle 6 is no longer supported; use Guzzle7AuthHandler.
  */
 class Guzzle6AuthHandler
 {

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,6 @@ use Google\AuthHandler\AuthHandlerFactory;
 use Google\Http\REST;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Ring\Client\StreamHandler;
 use InvalidArgumentException;
 use LogicException;
 use Monolog\Handler\StreamHandler as MonologStreamHandler;
@@ -1239,34 +1238,10 @@ class Client
 
     protected function createDefaultHttpClient()
     {
-        $guzzleVersion = null;
-        if (defined('\GuzzleHttp\ClientInterface::MAJOR_VERSION')) {
-            $guzzleVersion = ClientInterface::MAJOR_VERSION;
-        } elseif (defined('\GuzzleHttp\ClientInterface::VERSION')) {
-            $guzzleVersion = (int)substr(ClientInterface::VERSION, 0, 1);
-        }
-
-        if (5 === $guzzleVersion) {
-            $options = [
-                'base_url' => $this->config['base_path'],
-                'defaults' => ['exceptions' => false],
-            ];
-            if ($this->isAppEngine()) {
-                if (class_exists(StreamHandler::class)) {
-                    // set StreamHandler on AppEngine by default
-                    $options['handler'] = new StreamHandler();
-                    $options['defaults']['verify'] = '/etc/ca-certificates.crt';
-                }
-            }
-        } elseif (6 === $guzzleVersion || 7 === $guzzleVersion) {
-            // guzzle 6 or 7
-            $options = [
-                'base_uri' => $this->config['base_path'],
-                'http_errors' => false,
-            ];
-        } else {
-            throw new LogicException('Could not find supported version of Guzzle.');
-        }
+        $options = [
+            'base_uri' => $this->config['base_path'],
+            'http_errors' => false,
+        ];
 
         return new GuzzleClient($options);
     }

--- a/src/Http/REST.php
+++ b/src/Http/REST.php
@@ -84,11 +84,12 @@ class REST
             $response = $httpHandler($request);
         } catch (RequestException $e) {
             // if Guzzle throws an exception, catch it and handle the response
-            if (!$e->hasResponse()) {
+            // (on Guzzle 7 the response is on RequestException, but on Guzzle 8
+            // it is only on its ResponseException subclass)
+            $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
+            if (null === $response) {
                 throw $e;
             }
-
-            $response = $e->getResponse();
         }
 
         return self::decodeHttpResponse($response, $request, $expectedClass);

--- a/tests/Google/ClientTest.php
+++ b/tests/Google/ClientTest.php
@@ -68,12 +68,13 @@ class ClientTest extends BaseTest
         $property = $class->getProperty('stack');
         $property->setAccessible(true);
         $middlewares = $property->getValue($stack);
-        $middleware = array_pop($middlewares);
 
         if (null === $className) {
             // only the default middlewares have been added
-            $this->assertCount(3, $middlewares);
+            $defaultStack = (new GuzzleClient())->getConfig('handler');
+            $this->assertCount(count($property->getValue($defaultStack)), $middlewares);
         } else {
+            $middleware = array_pop($middlewares);
             $authClass = sprintf('Google\Auth\Middleware\%sMiddleware', $className);
             $this->assertInstanceOf($authClass, $middleware[0]);
         }
@@ -904,7 +905,7 @@ class ClientTest extends BaseTest
                 $callable(new Request('GET', '/fake-uri'), ['auth' => 'google_auth']);
             });
 
-        $httpClient = $this->prophesize('GuzzleHttp\ClientInterface');
+        $httpClient = $this->prophesize('GuzzleHttp\Client');
         $httpClient->getConfig()
             ->shouldBeCalled()
             ->willReturn(['handler' => $handler->reveal()]);

--- a/tests/Google/Http/RESTTest.php
+++ b/tests/Google/Http/RESTTest.php
@@ -21,9 +21,12 @@ use Google\Http\REST;
 use Google\Service\Exception as ServiceException;
 use Google\Tests\BaseTest;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
 
 class RESTTest extends BaseTest
 {
@@ -84,6 +87,37 @@ class RESTTest extends BaseTest
 
         $request = new Request('GET', 'http://httpbin.org/status/500');
         $response = $this->rest->doExecute($http, $request);
+    }
+
+    public function testRequestExceptionWithResponseIsHandled()
+    {
+        $this->expectException(ServiceException::class);
+        $this->expectExceptionCode(400);
+
+        $request = new Request('GET', 'http://www.example.com');
+        $response = new Response(400, [], Psr7\Utils::streamFor('{"error": "bad request"}'));
+
+        $http = $this->prophesize('GuzzleHttp\ClientInterface');
+        $http->send(Argument::type('Psr\Http\Message\RequestInterface'), [])
+            ->shouldBeCalledTimes(1)
+            ->willThrow(new ClientException('Bad Request', $request, $response));
+
+        $this->rest->doExecute($http->reveal(), $request);
+    }
+
+    public function testRequestExceptionWithoutResponseIsRethrown()
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('Request failed');
+
+        $request = new Request('GET', 'http://www.example.com');
+
+        $http = $this->prophesize('GuzzleHttp\ClientInterface');
+        $http->send(Argument::type('Psr\Http\Message\RequestInterface'), [])
+            ->shouldBeCalledTimes(1)
+            ->willThrow(new RequestException('Request failed', $request));
+
+        $this->rest->doExecute($http->reveal(), $request);
     }
 
     public function testDecodeEmptyResponse()


### PR DESCRIPTION
Guzzle 8.0.0 was released on July 20th. Lots of people want to use it, and thus popular packages in the ecosystem like this one need to be updated to support it, so here I am, adding support. I've also removed some dead code that is no longer reachable after a previous removal of support for Guzzle 6.

---

PR blocked by https://github.com/GoogleCloudPlatform/php-tools/pull/182.