### PR TITLE
fix: match batch response parts to requests by Content-ID

### DIFF
--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -164,6 +164,13 @@ EOF;
             $responses = [];
             $requests = array_values($this->requests);
 
+            // Key the requests the same way the API keys the response parts, so
+            // a part can be matched to the request which produced it.
+            $requestsByContentId = [];
+            foreach ($this->requests as $requestKey => $batchedRequest) {
+                $requestsByContentId['response-' . $requestKey] = $batchedRequest;
+            }
+
             foreach ($parts as $i => $part) {
                 $part = trim($part);
                 if (!empty($part)) {
@@ -184,8 +191,18 @@ EOF;
                     // Need content id.
                     $key = $headers['content-id'];
 
+                    // The parts are not guaranteed to be returned in the order
+                    // they were sent, so resolve the request and the expected
+                    // class from the content id, and only fall back to the
+                    // position of the part when the content id is unknown.
+                    $request = $requestsByContentId[$key] ?? ($requests[$i-1] ?? null);
+
                     try {
-                        $response = REST::decodeHttpResponse($response, $requests[$i-1]);
+                        $response = REST::decodeHttpResponse(
+                            $response,
+                            $request,
+                            $classes[$key] ?? null
+                        );
                     } catch (GoogleServiceException $e) {
                         // Store the exception as the response, so successful responses
                         // can be processed.

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -189,7 +189,7 @@ EOF;
                     );
 
                     // Need content id.
-                    $key = $headers['content-id'];
+                    $key = $headers['content-id'] ?? '';
 
                     // The parts are not guaranteed to be returned in the order
                     // they were sent, so resolve the request and the expected

--- a/src/Http/Batch.php
+++ b/src/Http/Batch.php
@@ -195,7 +195,7 @@ EOF;
                     // they were sent, so resolve the request and the expected
                     // class from the content id, and only fall back to the
                     // position of the part when the content id is unknown.
-                    $request = $requestsByContentId[$key] ?? ($requests[$i-1] ?? null);
+                    $request = $requestsByContentId[$key] ?? $requests[$i-1] ?? null;
 
                     try {
                         $response = REST::decodeHttpResponse(

--- a/tests/Google/Http/BatchTest.php
+++ b/tests/Google/Http/BatchTest.php
@@ -26,6 +26,8 @@ use Google\Service\Books;
 use Google\Service\Storage;
 use Google\Service\Exception as ServiceException;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 
 class BatchTest extends BaseTest
 {
@@ -63,6 +65,57 @@ class BatchTest extends BaseTest
             ServiceException::class,
             $result['response-key1']
         );
+    }
+
+    public function testParseResponseMatchesResponsesToRequestsByContentId()
+    {
+        // The API is not required to return the parts in the order they were
+        // sent, so each part must be matched to its request via its Content-ID.
+        $client = $this->getClient();
+        $batch = new Batch($client);
+        $batch->add(
+            (new Request('GET', 'http://foo.bar/volume'))
+                ->withHeader('X-Php-Expected-Class', Books\Volume::class),
+            'key1'
+        );
+        $batch->add(
+            (new Request('GET', 'http://foo.bar/bookshelf'))
+                ->withHeader('X-Php-Expected-Class', Books\Bookshelf::class),
+            'key2'
+        );
+
+        $boundary = 'batch_boundary';
+        $classes = [
+            'response-key1' => Books\Volume::class,
+            'response-key2' => Books\Bookshelf::class,
+        ];
+
+        // The parts come back in the reverse order of the requests.
+        $body = '';
+        foreach (['key2', 'key1'] as $key) {
+            $body .= "--$boundary\r\n"
+                . "Content-Type: application/http\r\n"
+                . "Content-ID: response-$key\r\n"
+                . "\r\n"
+                . "HTTP/1.1 200 OK\r\n"
+                . "Content-Type: application/json\r\n"
+                . "\r\n"
+                . '{"id": "' . $key . '"}' . "\r\n";
+        }
+        $body .= "--$boundary--";
+
+        $response = new Response(
+            200,
+            ['Content-Type' => "multipart/mixed; boundary=$boundary"],
+            $body
+        );
+
+        $result = $batch->parseResponse($response, $classes);
+
+        $this->assertInstanceOf(Books\Volume::class, $result['response-key1']);
+        $this->assertEquals('key1', $result['response-key1']->id);
+        $this->assertInstanceOf(Books\Bookshelf::class, $result['response-key2']);
+        $this->assertEquals('key2', $result['response-key2']->id);
     }
 
     public function testMediaFileBatch()


### PR DESCRIPTION
Batch::parseResponse() paired each response part with a request by position ($requests[$i-1]), and silently ignored the $classes map that execute() builds keyed by Content-ID. The batch API does not guarantee that parts come back in the order they were sent — that is why each part carries a Content-ID — so a reordered response was decoded into the wrong model class (or into a raw Response), and alt=media detection used the wrong request.

This was a regression from the Guzzle 6 rewrite, which replaced the Content-ID lookup (`if (isset($classes[$key]))`) with positional matching and left $classes as an unused parameter.

Resolve both the originating request and the expected class from the part's Content-ID, falling back to the previous positional behaviour when the Content-ID is not one we sent.